### PR TITLE
Expand auto-merge merge-method guidance

### DIFF
--- a/PR_AUTOMATION.md
+++ b/PR_AUTOMATION.md
@@ -596,6 +596,23 @@ auto_merge:
 **Merge:** Preserves all commits with merge commit
 **Rebase:** Replays commits on base branch
 
+#### Merge method selection guidance (critique)
+
+- **Main and release branches:** Prefer **merge commits** to preserve the original commit sequence, which keeps rollback options intact and maintains a faithful audit trail for production functionality.
+- **Feature branches:** Squash merges keep history tidy, but avoid them when the individual commits carry meaningful checkpoints (e.g., staged migrations or config toggles).
+- **Rebase:** Useful for keeping a clean history, but it rewrites commits—avoid rebasing shared release branches where history integrity is required.
+
+To enforce merge commits into `main` while allowing squash elsewhere:
+
+```yaml
+# .github/pr-automation.yml
+auto_merge:
+  merge_method: squash
+  merge_method_by_base:
+    main: merge          # Preserve full history on main
+    release/*: merge     # Keep release sequencing intact
+```
+
 ### Branch-Specific Rules
 
 ```yaml


### PR DESCRIPTION
## Summary
- add merge-method selection critique highlighting when merge commits preserve production history
- document configuration example enforcing merge commits on main and release branches while keeping squash elsewhere

## Testing
- not applicable (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938323e59a083238a09dd3dbb4d6971)

## Summary by Sourcery

Document guidance on selecting auto-merge methods and provide an example configuration enforcing merge commits on main and release branches while keeping squash merges elsewhere.

Documentation:
- Add guidance on when to use merge commits, squash merges, and rebases in auto-merge workflows.
- Document a sample configuration enforcing merge commits for main and release branches while defaulting to squash merges.