### PR TITLE
docs: enhance merge strategy guidance

### DIFF
--- a/GIT_WORKFLOW.md
+++ b/GIT_WORKFLOW.md
@@ -284,7 +284,9 @@ Choosing the right merge strategy is critical for preserving context and functio
   - ✅ **Use when** you need a linear history for small, isolated branches and tests are green after the rebase.
   - 🔍 **Critique**: Rewriting history can obscure when changes actually occurred; avoid for shared branches or when auditability is required.
 
-**Main branch default:** Favor `--no-ff` merge commits for release and hotfix branches to keep auditability and alignment with deployment checkpoints. Use squash merges for short-lived feature branches after confirming tests and reviews are complete.
+**Default Merge Strategies:**
+- **When merging to `main`:** Favor `--no-ff` merge commits for `release/*` and `hotfix/*` branches to preserve history and auditability.
+- **When merging to `develop`:** Use squash merges for `feature/*` branches to keep the integration history clean.
 
 ### Functional Preservation Checklist for Merging to Main
 

--- a/GIT_WORKFLOW.md
+++ b/GIT_WORKFLOW.md
@@ -281,8 +281,8 @@ Choosing the right merge strategy is critical for preserving context and functio
   - ✅ **Use when** the branch contains many small or iterative commits that should be represented as a single logical change.
   - 🔍 **Critique**: Loses granular commit messages and can hide the sequence of decisions; avoid for long-running feature or release branches.
 - **Rebase and merge**
-  - ✅ **Use when** you need a linear history for small, isolated branches and tests are green after the rebase.
-  - 🔍 **Critique**: Rewriting history can obscure when changes actually occurred; avoid for shared branches or when auditability is required.
+  - ✅ **Use when** you need a linear history for small, isolated branches.
+  - 🔍 **Critique**: Rewriting history can obscure when changes occurred and may introduce broken intermediate commits if not done carefully. This complicates debugging (e.g., `git bisect`). To mitigate this, use interactive rebase (`git rebase -i`) to ensure each commit is a self-contained, working change. Avoid for shared branches or when strict auditability is required.
 
 **Default Merge Strategies:**
 - **When merging to `main`:** Favor `--no-ff` merge commits for `release/*` and `hotfix/*` branches to preserve history and auditability.

--- a/GIT_WORKFLOW.md
+++ b/GIT_WORKFLOW.md
@@ -270,6 +270,35 @@ git push
 
 4. **Merge**: Once approved and checks pass
 
+### Merge Strategy Selection (Critique & Guidance)
+
+Choosing the right merge strategy is critical for preserving context and functionality when changes land on `main`.
+
+- **Merge commit (`--no-ff`)**
+  - ✅ **Use when** you want to preserve branch history, keep feature commits grouped, or when the branch includes coordinated work (multi-service changes, release branches).
+  - 🔍 **Critique**: Can increase history noise if used for trivial fixes; avoid for one-line changes unless they are production-impacting hotfixes.
+- **Squash merge**
+  - ✅ **Use when** the branch contains many small or iterative commits that should be represented as a single logical change.
+  - 🔍 **Critique**: Loses granular commit messages and can hide the sequence of decisions; avoid for long-running feature or release branches.
+- **Rebase and merge**
+  - ✅ **Use when** you need a linear history for small, isolated branches and tests are green after the rebase.
+  - 🔍 **Critique**: Rewriting history can obscure when changes actually occurred; avoid for shared branches or when auditability is required.
+
+**Main branch default:** Favor `--no-ff` merge commits for release and hotfix branches to keep auditability and alignment with deployment checkpoints. Use squash merges for short-lived feature branches after confirming tests and reviews are complete.
+
+### Functional Preservation Checklist for Merging to Main
+
+Before merging anything into `main`, validate that functionality remains intact:
+
+1. **Test signals**: All required CI checks are green (unit, integration, security scans). Re-run failed flaky tests before merging.
+2. **Backward compatibility**: Review public APIs, data migrations, and config changes for compatibility. Provide migration notes or feature flags when behavior changes.
+3. **Runtime safety**: Confirm feature flags, fallbacks, and rollbacks exist for risky changes. For release branches, ensure staged rollout plans are documented.
+4. **Documentation alignment**: Update README/CHANGELOG and operational runbooks so deployers understand expected behavior.
+5. **Dependency impacts**: Validate dependency updates against lockfiles and downstream consumers; note any manual steps in the PR description.
+6. **Post-merge verification plan**: Define a smoke test or monitoring check to run immediately after the merge to catch regressions early.
+
+> Tip: Treat the merge as a deployment gate—if you would not deploy it, do not merge it into `main`.
+
 ---
 
 ## Release Process


### PR DESCRIPTION
## Summary
- add merge strategy critique outlining when to use merge, squash, or rebase
- document default approach for main merges to preserve history and auditability
- provide a functional preservation checklist to validate readiness before merging into main

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938342862ac8323829b4467498ec4be)

## Summary by Sourcery

Document merge strategy guidance and pre-merge validation for changes landing on the main branch.

Documentation:
- Add guidance on when to use merge commits, squash merges, and rebase-and-merge in the git workflow.
- Document a functional preservation checklist to follow before merging branches into main.