### PR TITLE
[limen LIMEN-086] Secret Scanning Alert triage: 6862 potential leaks

### DIFF
--- a/.github/workflows/reusable/security-scanning.yml
+++ b/.github/workflows/reusable/security-scanning.yml
@@ -135,9 +135,13 @@ jobs:
       if: inputs.scan-type == 'secrets' || inputs.scan-type == 'all'
       run: |
         pip install detect-secrets==1.5.0
-        detect-secrets scan --all-files --baseline .secrets.baseline || true
-        if [ -f .secrets.baseline ]; then
-          echo "Secret scan complete. Review .secrets.baseline for any findings."
+        SECRET_BASELINE=".config/.secrets.baseline"
+        if [ -f "$SECRET_BASELINE" ]; then
+          detect-secrets scan --all-files --baseline "$SECRET_BASELINE" --exclude-files '(^|/)\.config/\.secrets\.baseline$' > detect-secrets-results.json || true
+          echo "Secret scan complete using $SECRET_BASELINE."
+        else
+          detect-secrets scan --all-files --exclude-files '(^|/)\.config/\.secrets\.baseline$' > detect-secrets-results.json || true
+          echo "Secret scan complete without a baseline."
         fi
 
     - name: Upload security scan artifacts
@@ -149,5 +153,7 @@ jobs:
           codeql-results/
           trivy-results.sarif
           semgrep.sarif
-          .secrets.baseline
+          detect-secrets-results.json
+          .config/.secrets.baseline
         retention-days: 30
+        include-hidden-files: true

--- a/.github/workflows/safeguard-5-secret-scanning.yml
+++ b/.github/workflows/safeguard-5-secret-scanning.yml
@@ -21,6 +21,10 @@ permissions:
   issues: write
   security-events: write
 
+env:
+  GITLEAKS_CONFIG: .config/.gitleaks.toml
+  DETECT_SECRETS_BASELINE: .config/.secrets.baseline
+
 jobs:
   pre-record-scan:
     name: Pre-Record Code Scanning
@@ -58,11 +62,10 @@ jobs:
         trufflehog3 -r . --format json --output trufflehog-results.json || true
 
         if [ -f "trufflehog-results.json" ] && [ -s "trufflehog-results.json" ]; then
-          echo "found_secrets=true" >> $GITHUB_OUTPUT
-          echo "TruffleHog found potential secrets!"
-          cat trufflehog-results.json
+          echo "found_secrets=true" >> "$GITHUB_OUTPUT"
+          echo "TruffleHog found potential secrets. Review the uploaded artifact for details."
         else
-          echo "found_secrets=false" >> $GITHUB_OUTPUT
+          echo "found_secrets=false" >> "$GITHUB_OUTPUT"
           echo "TruffleHog scan clean"
         fi
 
@@ -71,20 +74,25 @@ jobs:
       continue-on-error: true
       run: |
         echo "Running Gitleaks scan..."
-        # Use .gitleaks.toml config if it exists
-        if [ -f ".gitleaks.toml" ]; then
-          echo "Using .gitleaks.toml configuration"
-          gitleaks detect --source . --config .gitleaks.toml --report-format json --report-path gitleaks-report.json --verbose || true
+        if [ -f "$GITLEAKS_CONFIG" ]; then
+          echo "Using $GITLEAKS_CONFIG configuration"
+          gitleaks detect --source . --config "$GITLEAKS_CONFIG" --report-format json --report-path gitleaks-report.json --redact=100 --no-banner --no-color || true
         else
-          gitleaks detect --source . --report-format json --report-path gitleaks-report.json --verbose || true
+          echo "No Gitleaks config found at $GITLEAKS_CONFIG; using defaults"
+          gitleaks detect --source . --report-format json --report-path gitleaks-report.json --redact=100 --no-banner --no-color || true
         fi
 
         if [ -f "gitleaks-report.json" ] && [ -s "gitleaks-report.json" ]; then
-          echo "found_secrets=true" >> $GITHUB_OUTPUT
-          echo "Gitleaks found potential secrets!"
-          cat gitleaks-report.json | jq '.'
+          LEAK_COUNT=$(jq length gitleaks-report.json 2>/dev/null || echo "0")
+          if [ "$LEAK_COUNT" -gt 0 ]; then
+            echo "found_secrets=true" >> "$GITHUB_OUTPUT"
+            echo "Gitleaks found $LEAK_COUNT potential secrets. Review the uploaded artifact for details."
+          else
+            echo "found_secrets=false" >> "$GITHUB_OUTPUT"
+            echo "Gitleaks scan clean"
+          fi
         else
-          echo "found_secrets=false" >> $GITHUB_OUTPUT
+          echo "found_secrets=false" >> "$GITHUB_OUTPUT"
           echo "Gitleaks scan clean"
         fi
 
@@ -93,26 +101,25 @@ jobs:
       continue-on-error: true
       run: |
         echo "Running detect-secrets scan..."
-        # Use baseline if it exists
-        if [ -f ".secrets.baseline" ]; then
-          echo "Using .secrets.baseline for comparison"
-          detect-secrets scan --all-files --force-use-all-plugins --baseline .secrets.baseline > detect-secrets-results.json || true
+        if [ -f "$DETECT_SECRETS_BASELINE" ]; then
+          echo "Using $DETECT_SECRETS_BASELINE for comparison"
+          detect-secrets scan --all-files --force-use-all-plugins --baseline "$DETECT_SECRETS_BASELINE" --exclude-files '(^|/)\.config/\.secrets\.baseline$' > detect-secrets-results.json || true
         else
-          detect-secrets scan --all-files --force-use-all-plugins > detect-secrets-results.json || true
+          echo "No detect-secrets baseline found at $DETECT_SECRETS_BASELINE; scanning without baseline"
+          detect-secrets scan --all-files --force-use-all-plugins --exclude-files '(^|/)\.config/\.secrets\.baseline$' > detect-secrets-results.json || true
         fi
 
         if [ -f "detect-secrets-results.json" ]; then
-          RESULTS_COUNT=$(cat detect-secrets-results.json | jq '.results | length')
+          RESULTS_COUNT=$(jq '.results | length' detect-secrets-results.json 2>/dev/null || echo "0")
           if [ "$RESULTS_COUNT" -gt 0 ]; then
-            echo "found_secrets=true" >> $GITHUB_OUTPUT
-            echo "detect-secrets found $RESULTS_COUNT potential secrets!"
-            cat detect-secrets-results.json | jq '.results'
+            echo "found_secrets=true" >> "$GITHUB_OUTPUT"
+            echo "detect-secrets found potential secrets in $RESULTS_COUNT files. Review the uploaded artifact for details."
           else
-            echo "found_secrets=false" >> $GITHUB_OUTPUT
+            echo "found_secrets=false" >> "$GITHUB_OUTPUT"
             echo "detect-secrets scan clean"
           fi
         else
-          echo "found_secrets=false" >> $GITHUB_OUTPUT
+          echo "found_secrets=false" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Upload scan results
@@ -383,28 +390,30 @@ jobs:
     steps:
     - name: Generate summary
       run: |
-        echo "## 🔒 Secret Scanning Summary" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "**Workflow:** Safeguard 5 - Secret Scanning" >> $GITHUB_STEP_SUMMARY
-        echo "**Status:** ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
-        echo "**Timestamp:** $(date -u +'%Y-%m-%d %H:%M:%S UTC')" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
-        echo "### Scan Results" >> $GITHUB_STEP_SUMMARY
-        echo "- Pre-Record Code Scan: ${{ needs.pre-record-scan.result || 'skipped' }}" >> $GITHUB_STEP_SUMMARY
-        echo "- Post-Record Video Scan: ${{ needs.post-record-video-scan.result || 'skipped' }}" >> $GITHUB_STEP_SUMMARY
-        echo "" >> $GITHUB_STEP_SUMMARY
+        {
+          echo "## 🔒 Secret Scanning Summary"
+          echo ""
+          echo "**Workflow:** Safeguard 5 - Secret Scanning"
+          echo "**Status:** ${{ job.status }}"
+          echo "**Timestamp:** $(date -u +'%Y-%m-%d %H:%M:%S UTC')"
+          echo ""
+          echo "### Scan Results"
+          echo "- Pre-Record Code Scan: ${{ needs.pre-record-scan.result || 'skipped' }}"
+          echo "- Post-Record Video Scan: ${{ needs.post-record-video-scan.result || 'skipped' }}"
+          echo ""
 
-        if [ "${{ needs.pre-record-scan.result }}" == "failure" ] || [ "${{ needs.post-record-video-scan.result }}" == "failure" ]; then
-          echo "### ⚠️ Action Required" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Potential secrets were detected. Please review the scan results and:" >> $GITHUB_STEP_SUMMARY
-          echo "1. Remove all secrets from the codebase" >> $GITHUB_STEP_SUMMARY
-          echo "2. Rotate any exposed credentials" >> $GITHUB_STEP_SUMMARY
-          echo "3. Regenerate the walkthrough video" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**DO NOT MERGE** until this issue is resolved." >> $GITHUB_STEP_SUMMARY
-        else
-          echo "### ✅ All Clear" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "No secrets detected in pre-record scan or video frames." >> $GITHUB_STEP_SUMMARY
-        fi
+          if [ "${{ needs.pre-record-scan.result }}" == "failure" ] || [ "${{ needs.post-record-video-scan.result }}" == "failure" ]; then
+            echo "### ⚠️ Action Required"
+            echo ""
+            echo "Potential secrets were detected. Please review the scan results and:"
+            echo "1. Remove all secrets from the codebase"
+            echo "2. Rotate any exposed credentials"
+            echo "3. Regenerate the walkthrough video"
+            echo ""
+            echo "**DO NOT MERGE** until this issue is resolved."
+          else
+            echo "### ✅ All Clear"
+            echo ""
+            echo "No secrets detected in pre-record scan or video frames."
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/scan-for-secrets.yml
+++ b/.github/workflows/scan-for-secrets.yml
@@ -36,6 +36,10 @@ permissions:
   issues: write
   pull-requests: write
 
+env:
+  GITLEAKS_CONFIG: .config/.gitleaks.toml
+  DETECT_SECRETS_BASELINE: .config/.secrets.baseline
+
 jobs:
   scan-code:
     runs-on: ubuntu-latest
@@ -75,12 +79,12 @@ jobs:
 
         FINDING_COUNT=$(jq 'length' trufflehog-results.json 2>/dev/null || echo "0")
         if [ "$FINDING_COUNT" -gt 0 ]; then
-          echo "found_secrets=true" >> $GITHUB_OUTPUT
-          echo "finding_count=$FINDING_COUNT" >> $GITHUB_OUTPUT
+          echo "found_secrets=true" >> "$GITHUB_OUTPUT"
+          echo "finding_count=$FINDING_COUNT" >> "$GITHUB_OUTPUT"
           echo "⚠️ TruffleHog found $FINDING_COUNT potential secrets"
         else
-          echo "found_secrets=false" >> $GITHUB_OUTPUT
-          echo "finding_count=0" >> $GITHUB_OUTPUT
+          echo "found_secrets=false" >> "$GITHUB_OUTPUT"
+          echo "finding_count=0" >> "$GITHUB_OUTPUT"
           echo "✅ TruffleHog scan clean"
         fi
 
@@ -89,28 +93,28 @@ jobs:
       continue-on-error: true
       run: |
         echo "🔍 Running Gitleaks scan..."
-        # Use .gitleaks.toml config if it exists
-        if [ -f ".gitleaks.toml" ]; then
-          echo "Using .gitleaks.toml configuration"
-          gitleaks detect --source . --config .gitleaks.toml --report-format json --report-path gitleaks-results.json --verbose || true
+        if [ -f "$GITLEAKS_CONFIG" ]; then
+          echo "Using $GITLEAKS_CONFIG configuration"
+          gitleaks detect --source . --config "$GITLEAKS_CONFIG" --report-format json --report-path gitleaks-results.json --redact=100 --no-banner --no-color || true
         else
-          gitleaks detect --source . --report-format json --report-path gitleaks-results.json --verbose || true
+          echo "No Gitleaks config found at $GITLEAKS_CONFIG; using defaults"
+          gitleaks detect --source . --report-format json --report-path gitleaks-results.json --redact=100 --no-banner --no-color || true
         fi
 
         if [ -f "gitleaks-results.json" ] && [ -s "gitleaks-results.json" ]; then
-          LEAK_COUNT=$(jq length gitleaks-results.json)
+          LEAK_COUNT=$(jq length gitleaks-results.json 2>/dev/null || echo "0")
           if [ "$LEAK_COUNT" -gt 0 ]; then
-            echo "found_secrets=true" >> $GITHUB_OUTPUT
-            echo "leak_count=$LEAK_COUNT" >> $GITHUB_OUTPUT
+            echo "found_secrets=true" >> "$GITHUB_OUTPUT"
+            echo "leak_count=$LEAK_COUNT" >> "$GITHUB_OUTPUT"
             echo "⚠️ Gitleaks found $LEAK_COUNT potential secrets"
           else
-            echo "found_secrets=false" >> $GITHUB_OUTPUT
-            echo "leak_count=0" >> $GITHUB_OUTPUT
+            echo "found_secrets=false" >> "$GITHUB_OUTPUT"
+            echo "leak_count=0" >> "$GITHUB_OUTPUT"
             echo "✅ Gitleaks scan clean"
           fi
         else
-          echo "found_secrets=false" >> $GITHUB_OUTPUT
-          echo "leak_count=0" >> $GITHUB_OUTPUT
+          echo "found_secrets=false" >> "$GITHUB_OUTPUT"
+          echo "leak_count=0" >> "$GITHUB_OUTPUT"
           echo "✅ Gitleaks scan clean"
         fi
 
@@ -119,28 +123,28 @@ jobs:
       continue-on-error: true
       run: |
         echo "🔍 Running detect-secrets scan..."
-        # Use baseline if it exists
-        if [ -f ".secrets.baseline" ]; then
-          echo "Using .secrets.baseline for comparison"
-          detect-secrets scan --all-files --force-use-all-plugins --baseline .secrets.baseline > detect-secrets-results.json || true
+        if [ -f "$DETECT_SECRETS_BASELINE" ]; then
+          echo "Using $DETECT_SECRETS_BASELINE for comparison"
+          detect-secrets scan --all-files --force-use-all-plugins --baseline "$DETECT_SECRETS_BASELINE" --exclude-files '(^|/)\.config/\.secrets\.baseline$' > detect-secrets-results.json || true
         else
-          detect-secrets scan --all-files --force-use-all-plugins > detect-secrets-results.json || true
+          echo "No detect-secrets baseline found at $DETECT_SECRETS_BASELINE; scanning without baseline"
+          detect-secrets scan --all-files --force-use-all-plugins --exclude-files '(^|/)\.config/\.secrets\.baseline$' > detect-secrets-results.json || true
         fi
 
         if [ -f "detect-secrets-results.json" ]; then
           SECRET_COUNT=$(jq '.results | to_entries | length' detect-secrets-results.json 2>/dev/null || echo "0")
           if [ "$SECRET_COUNT" -gt 0 ]; then
-            echo "found_secrets=true" >> $GITHUB_OUTPUT
-            echo "secret_count=$SECRET_COUNT" >> $GITHUB_OUTPUT
+            echo "found_secrets=true" >> "$GITHUB_OUTPUT"
+            echo "secret_count=$SECRET_COUNT" >> "$GITHUB_OUTPUT"
             echo "⚠️ detect-secrets found secrets in $SECRET_COUNT files"
           else
-            echo "found_secrets=false" >> $GITHUB_OUTPUT
-            echo "secret_count=0" >> $GITHUB_OUTPUT
+            echo "found_secrets=false" >> "$GITHUB_OUTPUT"
+            echo "secret_count=0" >> "$GITHUB_OUTPUT"
             echo "✅ detect-secrets scan clean"
           fi
         else
-          echo "found_secrets=false" >> $GITHUB_OUTPUT
-          echo "secret_count=0" >> $GITHUB_OUTPUT
+          echo "found_secrets=false" >> "$GITHUB_OUTPUT"
+          echo "secret_count=0" >> "$GITHUB_OUTPUT"
           echo "✅ detect-secrets scan clean"
         fi
 
@@ -195,7 +199,7 @@ jobs:
           ### Action Required
 
           1. **Review the scan results** attached to this workflow run
-          2. **Identify false positives** and update .gitleaks.toml or .secrets.baseline if needed
+          2. **Identify false positives** and update \`.config/.gitleaks.toml\` or \`.config/.secrets.baseline\` if needed
           3. **Rotate any real secrets** that were detected
           4. **Remove secrets from git history** using tools like BFG Repo-Cleaner or git-filter-repo
           5. **Update affected videos** if secrets appear in walkthrough recordings
@@ -293,14 +297,14 @@ jobs:
       id: find-videos
       run: |
         VIDEO_COUNT=$(find . -type f \( -name "*.mp4" -o -name "*.mkv" -o -name "*.mov" \) | wc -l)
-        echo "video_count=$VIDEO_COUNT" >> $GITHUB_OUTPUT
+        echo "video_count=$VIDEO_COUNT" >> "$GITHUB_OUTPUT"
 
         if [ "$VIDEO_COUNT" -eq 0 ]; then
           echo "No video files found"
-          echo "has_videos=false" >> $GITHUB_OUTPUT
+          echo "has_videos=false" >> "$GITHUB_OUTPUT"
         else
           echo "Found $VIDEO_COUNT video files"
-          echo "has_videos=true" >> $GITHUB_OUTPUT
+          echo "has_videos=true" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Extract frames from videos
@@ -308,7 +312,7 @@ jobs:
       run: |
         mkdir -p video-frames
 
-        find . -type f \( -name "*.mp4" -o -name "*.mkv" -o -name "*.mov" \) | while read video; do
+        find . -type f \( -name "*.mp4" -o -name "*.mkv" -o -name "*.mov" \) | while read -r video; do
           video_name=$(basename "$video" | sed 's/\.[^.]*$//')
           echo "Processing: $video"
 
@@ -373,15 +377,15 @@ jobs:
         if [ -f "video-ocr-results.json" ]; then
           FINDING_COUNT=$(jq 'length' video-ocr-results.json)
           if [ "$FINDING_COUNT" -gt 0 ]; then
-            echo "found_secrets=true" >> $GITHUB_OUTPUT
-            echo "finding_count=$FINDING_COUNT" >> $GITHUB_OUTPUT
+            echo "found_secrets=true" >> "$GITHUB_OUTPUT"
+            echo "finding_count=$FINDING_COUNT" >> "$GITHUB_OUTPUT"
             echo "⚠️ Found $FINDING_COUNT potential secrets in videos"
           else
-            echo "found_secrets=false" >> $GITHUB_OUTPUT
+            echo "found_secrets=false" >> "$GITHUB_OUTPUT"
             echo "✅ No secrets found in videos"
           fi
         else
-          echo "found_secrets=false" >> $GITHUB_OUTPUT
+          echo "found_secrets=false" >> "$GITHUB_OUTPUT"
           echo "✅ No secrets found in videos"
         fi
 
@@ -468,17 +472,15 @@ jobs:
     - name: Summary
       if: always()
       run: |
-        cat >> $GITHUB_STEP_SUMMARY << 'EOF'
+        cat >> "$GITHUB_STEP_SUMMARY" << 'EOF'
         ## 🔒 Secret Scanning Summary
 
         ### Code Scanning
-        - TruffleHog: ${{ steps.trufflehog.outputs.found_secrets == 'true' && '⚠️ Secrets Found' || '✅ Clean' }}
-        - Gitleaks: ${{ steps.gitleaks.outputs.found_secrets == 'true' && '⚠️ Secrets Found' || '✅ Clean' }}
-        - detect-secrets: ${{ steps.detect-secrets.outputs.found_secrets == 'true' && '⚠️ Secrets Found' || '✅ Clean' }}
+        - Results: See the `Pre-record: Scan Code for Secrets` job in this workflow run.
 
         ### Video Scanning
         - Videos Scanned: ${{ steps.find-videos.outputs.video_count || '0' }}
         - OCR Analysis: ${{ steps.ocr-scan.outputs.found_secrets == 'true' && '⚠️ Secrets Found' || '✅ Clean' }}
 
-        ${{ (steps.trufflehog.outputs.found_secrets == 'true' || steps.gitleaks.outputs.found_secrets == 'true' || steps.detect-secrets.outputs.found_secrets == 'true' || steps.ocr-scan.outputs.found_secrets == 'true') && '⚠️ **Action Required**: Review the findings and take appropriate action' || '✅ **All Clear**: No secrets detected' }}
+        ${{ steps.ocr-scan.outputs.found_secrets == 'true' && '⚠️ **Action Required**: Review the video OCR findings and take appropriate action' || '✅ **Video Scan Clear**: No secrets detected in video frames' }}
         EOF

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -94,7 +94,7 @@ jobs:
         # Scan current filesystem only (--no-git), not full git history
         # History scanning finds thousands of false positives from old commits
         if [ -f ".config/.gitleaks.toml" ]; then
-          gitleaks detect --source . --no-git --config .config/.gitleaks.toml --verbose
+          gitleaks detect --source . --no-git --config .config/.gitleaks.toml --redact=100 --no-banner --no-color
         else
-          gitleaks detect --source . --no-git --verbose
+          gitleaks detect --source . --no-git --redact=100 --no-banner --no-color
         fi

--- a/docs/guides/SECRET_SCANNING_GUIDE.md
+++ b/docs/guides/SECRET_SCANNING_GUIDE.md
@@ -46,7 +46,7 @@ We use three complementary tools to scan for secrets:
 
 ## Configuration Files
 
-### .gitleaks.toml
+### .config/.gitleaks.toml
 
 Configuration for Gitleaks scanner that defines:
 
@@ -62,7 +62,7 @@ Configuration for Gitleaks scanner that defines:
 - Agent files describing patterns
 - Test configurations
 
-### .secrets.baseline
+### .config/.secrets.baseline
 
 Baseline file for detect-secrets containing:
 
@@ -73,7 +73,7 @@ Baseline file for detect-secrets containing:
 Generated with:
 
 ```bash
-detect-secrets scan --all-files --force-use-all-plugins > .secrets.baseline
+detect-secrets scan --all-files --force-use-all-plugins > .config/.secrets.baseline
 ```
 
 ## Managing False Positives
@@ -86,7 +86,7 @@ detect-secrets scan --all-files --force-use-all-plugins > .secrets.baseline
    - Is it a pattern definition in the scanner itself?
    - Is it a placeholder like `xxx`, `example`, `your-token-here`?
 
-1. **Update .gitleaks.toml** to allowlist:
+1. **Update `.config/.gitleaks.toml`** to allowlist:
 
 ```toml
 # Add to allowlist.paths
@@ -100,14 +100,14 @@ regexes = [
 ]
 ```
 
-3. **Update .secrets.baseline** for detect-secrets:
+3. **Update `.config/.secrets.baseline`** for detect-secrets:
 
 ```bash
 # Regenerate baseline to include new false positives
-detect-secrets scan --all-files --force-use-all-plugins > .secrets.baseline
+detect-secrets scan --all-files --force-use-all-plugins > .config/.secrets.baseline
 
 # Or audit and update existing findings
-detect-secrets audit .secrets.baseline
+detect-secrets audit .config/.secrets.baseline
 ```
 
 4. **Commit both files** to the repository
@@ -218,7 +218,7 @@ If detect-secrets baseline regeneration fails:
 1. Ensure detect-secrets is installed: `pip install detect-secrets`
 1. Check file permissions
 1. Try clearing and regenerating:
-   `rm .secrets.baseline && detect-secrets scan ...`
+   `rm .config/.secrets.baseline && detect-secrets scan ...`
 1. Update detect-secrets: `pip install --upgrade detect-secrets`
 
 ## Workflow Architecture
@@ -268,18 +268,18 @@ For questions or issues with secret scanning:
 
 1. Check this guide first
 1. Review workflow logs in GitHub Actions
-1. Check `.gitleaks.toml` and `.secrets.baseline` configuration
+1. Check `.config/.gitleaks.toml` and `.config/.secrets.baseline` configuration
 1. Open an issue with the `security` label
 1. Contact the security team: @security-team
 
 ______________________________________________________________________
 
-**Last Updated**: 2025-12-25\
+**Last Updated**: 2026-06-18\
 **Maintained By**: Security Team\
 **Related
 Files**:
 
-- `.gitleaks.toml`
-- `.secrets.baseline`
+- `.config/.gitleaks.toml`
+- `.config/.secrets.baseline`
 - `.github/workflows/scan-for-secrets.yml`
 - `.github/workflows/safeguard-5-secret-scanning.yml`

--- a/docs/runbooks/SECRET_SCANNING_RESOLUTION.md
+++ b/docs/runbooks/SECRET_SCANNING_RESOLUTION.md
@@ -19,6 +19,35 @@ scanning tools reported clean results**:
 - ✅ **Gitleaks**: Clean (no secrets found)
 - ✅ **detect-secrets**: Clean (no secrets found)
 
+## 2026-06 Follow-up Triage (LIMEN-086)
+
+Issue
+[#441](https://github.com/organvm-i-theoria/.github/issues/441) reported a
+repeatable daily alert from 2026-06-02 through 2026-06-07:
+
+- ✅ **TruffleHog**: Clean
+- ⚠️ **Gitleaks**: 6862 potential leaks
+- ⚠️ **detect-secrets**: 43 files with secrets
+
+This was a scanner configuration mismatch, not evidence of active leaked
+credentials. The repository stores scanner state under `.config/`, but the
+scheduled workflow only looked for root-level `.gitleaks.toml` and
+`.secrets.baseline`. As a result, Gitleaks ran with its default rules, scanned
+`.config/.secrets.baseline` as ordinary source, and reported thousands of
+hashed baseline entries plus documentation/test placeholders. Local
+verification with `.config/.gitleaks.toml` produced zero Gitleaks findings.
+
+### Follow-up Fix
+
+1. Updated the secret-scanning workflows to use:
+   - `.config/.gitleaks.toml`
+   - `.config/.secrets.baseline`
+1. Excluded `.config/.secrets.baseline` from fresh detect-secrets scans.
+1. Removed verbose scanner output that printed candidate values into workflow
+   logs.
+1. Fixed the Safeguard 5 Gitleaks step so an empty JSON report (`[]`) is
+   counted as clean instead of as a finding.
+
 ### Root Cause
 
 The workflow failed due to a **Python setup error**, not because secrets were
@@ -45,14 +74,14 @@ A manual scan of the repository confirmed:
 
 ### Changes Made
 
-1. **Created `.gitleaks.toml`** - Configuration file for Gitleaks scanner
+1. **Created `.config/.gitleaks.toml`** - Configuration file for Gitleaks scanner
 
    - Allowlists documentation files with example patterns
    - Allowlists workflow files that define patterns
    - Defines stop words for placeholders (example, xxx, etc.)
    - Custom rules for API keys, tokens, and private keys
 
-1. **Created `.secrets.baseline`** - Baseline file for detect-secrets
+1. **Created `.config/.secrets.baseline`** - Baseline file for detect-secrets
 
    - Generated with all plugins enabled
    - Contains 26 verified false positives across 20 files
@@ -66,8 +95,8 @@ A manual scan of the repository confirmed:
 
 1. **Updated Workflows**
 
-   - Both workflows now use `.gitleaks.toml` configuration
-   - Both workflows now use `.secrets.baseline` for comparison
+   - Both workflows now use `.config/.gitleaks.toml` configuration
+   - Both workflows now use `.config/.secrets.baseline` for comparison
    - Better error handling and clearer output messages
 
 1. **Created Documentation**
@@ -81,8 +110,8 @@ A manual scan of the repository confirmed:
 ### Files Changed
 
 ```
-.gitleaks.toml                                    [NEW]
-.secrets.baseline                                 [NEW]
+.config/.gitleaks.toml                            [NEW]
+.config/.secrets.baseline                         [NEW]
 docs/SECRET_SCANNING_GUIDE.md                     [NEW]
 .github/workflows/scan-for-secrets.yml            [MODIFIED]
 .github/workflows/safeguard-5-secret-scanning.yml [MODIFIED]
@@ -93,9 +122,9 @@ docs/SECRET_SCANNING_GUIDE.md                     [NEW]
 ### Configuration Validation
 
 ✅ All workflow YAML files are syntactically valid\
-✅ `.gitleaks.toml`
+✅ `.config/.gitleaks.toml`
 configuration is valid TOML\
-✅ `.secrets.baseline` contains 26 verified false
+✅ `.config/.secrets.baseline` contains verified false
 positives\
 ✅ No actual secrets detected in repository
 
@@ -186,7 +215,7 @@ fixed\
 
    - Review scan results weekly
    - Update baseline when adding new examples
-   - Keep `.gitleaks.toml` rules current
+   - Keep `.config/.gitleaks.toml` rules current
    - Monitor workflow success rate
 
 ## References

--- a/docs/runbooks/SECRET_SCANNING_RESOLUTION.md
+++ b/docs/runbooks/SECRET_SCANNING_RESOLUTION.md
@@ -21,8 +21,7 @@ scanning tools reported clean results**:
 
 ## 2026-06 Follow-up Triage (LIMEN-086)
 
-Issue
-[#441](https://github.com/organvm-i-theoria/.github/issues/441) reported a
+Issue [#441](https://github.com/organvm-i-theoria/.github/issues/441) reported a
 repeatable daily alert from 2026-06-02 through 2026-06-07:
 
 - ✅ **TruffleHog**: Clean
@@ -33,9 +32,9 @@ This was a scanner configuration mismatch, not evidence of active leaked
 credentials. The repository stores scanner state under `.config/`, but the
 scheduled workflow only looked for root-level `.gitleaks.toml` and
 `.secrets.baseline`. As a result, Gitleaks ran with its default rules, scanned
-`.config/.secrets.baseline` as ordinary source, and reported thousands of
-hashed baseline entries plus documentation/test placeholders. Local
-verification with `.config/.gitleaks.toml` produced zero Gitleaks findings.
+`.config/.secrets.baseline` as ordinary source, and reported thousands of hashed
+baseline entries plus documentation/test placeholders. Local verification with
+`.config/.gitleaks.toml` produced zero Gitleaks findings.
 
 ### Follow-up Fix
 
@@ -45,8 +44,8 @@ verification with `.config/.gitleaks.toml` produced zero Gitleaks findings.
 1. Excluded `.config/.secrets.baseline` from fresh detect-secrets scans.
 1. Removed verbose scanner output that printed candidate values into workflow
    logs.
-1. Fixed the Safeguard 5 Gitleaks step so an empty JSON report (`[]`) is
-   counted as clean instead of as a finding.
+1. Fixed the Safeguard 5 Gitleaks step so an empty JSON report (`[]`) is counted
+   as clean instead of as a finding.
 
 ### Root Cause
 
@@ -74,7 +73,8 @@ A manual scan of the repository confirmed:
 
 ### Changes Made
 
-1. **Created `.config/.gitleaks.toml`** - Configuration file for Gitleaks scanner
+1. **Created `.config/.gitleaks.toml`** - Configuration file for Gitleaks
+   scanner
 
    - Allowlists documentation files with example patterns
    - Allowlists workflow files that define patterns
@@ -124,8 +124,8 @@ docs/SECRET_SCANNING_GUIDE.md                     [NEW]
 ✅ All workflow YAML files are syntactically valid\
 ✅ `.config/.gitleaks.toml`
 configuration is valid TOML\
-✅ `.config/.secrets.baseline` contains verified false
-positives\
+✅ `.config/.secrets.baseline` contains verified
+false positives\
 ✅ No actual secrets detected in repository
 
 ### Next Steps


### PR DESCRIPTION
Autonomous **limen** dispatch of task `LIMEN-086`.

Audited 2026-06-01 from Jules-ready batch. Secret Scanning Alert triage: 6862 potential leaks

Refs: https://github.com/organvm-i-theoria/.github/issues/441

_Produced in an isolated worktree off origin — review before merge._

## Summary by Sourcery

Align secret scanning workflows and documentation with centralized scanner configuration under .config/, and reduce noise and exposure in secret scanning results and summaries.

Enhancements:
- Configure TruffleHog, Gitleaks, and detect-secrets workflows to use shared environment variables pointing at .config/.gitleaks.toml and .config/.secrets.baseline.
- Exclude the baseline file from detect-secrets scans and treat empty Gitleaks JSON reports as clean to avoid false positives from scanner state.
- Stop printing full scanner JSON outputs into workflow logs, tighten use of $GITHUB_OUTPUT, and simplify job summaries to direct users to artifacts and key results.
- Update the reusable security-scanning workflow to write detect-secrets findings to a JSON artifact and always upload both results and baseline, including hidden files.
- Adjust video secret-scanning steps for safer output handling and more robust shell usage.

Documentation:
- Extend the secret scanning resolution runbook with the LIMEN-086 triage, its root cause in config mismatch, and the follow-up changes to workflows and config locations.
- Update the secret scanning guide to reference .config/.gitleaks.toml and .config/.secrets.baseline paths, commands, and maintenance guidance, and bump the last updated date.