### PR TITLE
[limen RESOLVE-organvm-i-theoria-.github-457] resolve .github#457 (BLOCKED)

### DIFF
--- a/.github/workflows/staggered-scheduling.yml
+++ b/.github/workflows/staggered-scheduling.yml
@@ -38,6 +38,8 @@ jobs:
     outputs:
       has_schedule: ${{ steps.generate.outputs.has_schedule }}
       repos_today: ${{ steps.check-today.outputs.repos_today }}
+      schedule_date: ${{ steps.check-today.outputs.schedule_date }}
+      stagger_minutes: ${{ steps.check-today.outputs.stagger_minutes }}
 
     steps:
     - name: Checkout repository
@@ -94,96 +96,57 @@ jobs:
         REPO_COUNT=$(jq 'length' repositories.json)
         echo "repo_count=$REPO_COUNT" >> $GITHUB_OUTPUT
 
-    - name: Generate staggered schedule
+    - name: Plan staggered schedule
       id: generate
       env:
-        REPOSITORIES_PER_DAY: ${{ github.event.inputs.repositories_per_day || '10' }}
+        REPOSITORIES_PER_DAY: ${{ github.event.inputs.repositories_per_day || env.REPOS_PER_DAY }}
+        FORCE_RESCHEDULE: ${{ github.event.inputs.force_reschedule || 'false' }}
       run: |
-        cat > generate_schedule.py << 'EOF'
-        import json
-        import math
-        import os
-        from datetime import datetime, timedelta
+        TODAY=$(date -u +%Y-%m-%d)
 
-        # Load repositories
-        with open('repositories.json', 'r') as f:
-            repos = json.load(f)
-
-        repos_per_day = int(os.environ.get('REPOSITORIES_PER_DAY', '10'))
-        total_repos = len(repos)
-        days_needed = math.ceil(total_repos / repos_per_day)
-
-        print(f"Total repositories: {total_repos}")
-        print(f"Repositories per day: {repos_per_day}")
-        print(f"Days needed: {days_needed}")
-
-        # Sort repos by size (smaller repos first for faster initial runs)
-        repos.sort(key=lambda x: x['size'])
-
-        # Generate schedule
-        schedule = {
-            'version': '1.0',
-            'generated_at': datetime.utcnow().isoformat() + 'Z',
-            'repos_per_day': repos_per_day,
-            'total_repositories': total_repos,
-            'schedule_days': days_needed,
-            'schedule': {}
-        }
-
-        start_date = datetime.utcnow().date()
-
-        for day_offset in range(days_needed):
-            date = (start_date + timedelta(days=day_offset)).isoformat()
-            start_idx = day_offset * repos_per_day
-            end_idx = min(start_idx + repos_per_day, total_repos)
-
-            day_repos = repos[start_idx:end_idx]
-
-            schedule['schedule'][date] = {
-                'date': date,
-                'repositories': [r['full_name'] for r in day_repos],
-                'count': len(day_repos),
-                'status': 'pending',
-                'stagger_minutes': 5  # 5 minutes between each repo
-            }
-
-        with open('schedule.json', 'w') as f:
-            json.dump(schedule, f, indent=2)
-
-        print(f"Generated schedule for {days_needed} days")
-        EOF
-
-        python generate_schedule.py
-
-        echo "has_schedule=true" >> $GITHUB_OUTPUT
+        python src/automation/scripts/staggered_walkthrough_schedule.py plan \
+          --repositories repositories.json \
+          --schedule-file "${{ env.SCHEDULE_FILE }}" \
+          --output schedule.json \
+          --repos-per-day "$REPOSITORIES_PER_DAY" \
+          --force "$FORCE_RESCHEDULE" \
+          --today "$TODAY"
 
     - name: Save schedule
       run: |
-        mkdir -p .github/scheduling
-        mv schedule.json ${{ env.SCHEDULE_FILE }}
+        mkdir -p "$(dirname "${{ env.SCHEDULE_FILE }}")"
+        mv schedule.json "${{ env.SCHEDULE_FILE }}"
 
         git config user.name "github-actions[bot]"
         git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add .github/scheduling/
-        git commit -m "chore: update staggered schedule [skip ci]" || echo "No changes to commit"
-        git push || echo "No changes to push"
+        git add "${{ env.SCHEDULE_FILE }}"
+
+        if git diff --staged --quiet; then
+          echo "No schedule changes to commit"
+        else
+          git commit -m "chore: update staggered schedule [skip ci]"
+          git push
+        fi
 
     - name: Check today's schedule
       id: check-today
       run: |
         if [ ! -f "${{ env.SCHEDULE_FILE }}" ]; then
           echo "repos_today=0" >> $GITHUB_OUTPUT
+          echo "schedule_date=" >> $GITHUB_OUTPUT
+          echo "stagger_minutes=5" >> $GITHUB_OUTPUT
           exit 0
         fi
 
-        TODAY=$(date -u +%Y-%m-%d)
+        python src/automation/scripts/staggered_walkthrough_schedule.py due \
+          --schedule-file "${{ env.SCHEDULE_FILE }}" \
+          --repos-output repos_today.txt \
+          --today "$(date -u +%Y-%m-%d)"
 
-        REPOS_TODAY=$(jq -r ".schedule[\"$TODAY\"].repositories // [] | length" ${{ env.SCHEDULE_FILE }})
-        echo "repos_today=$REPOS_TODAY" >> $GITHUB_OUTPUT
-
+        REPOS_TODAY=$(wc -l < repos_today.txt | tr -d ' ')
         if [ "$REPOS_TODAY" -gt 0 ]; then
           echo "📋 Today's schedule: $REPOS_TODAY repositories"
-          jq -r ".schedule[\"$TODAY\"].repositories[]" ${{ env.SCHEDULE_FILE }} > repos_today.txt
+          cat repos_today.txt
         else
           echo "✅ No repositories scheduled for today"
         fi
@@ -205,6 +168,11 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # ratchet:actions/checkout@v6.0.2
+      with:
+        fetch-depth: 1
+        ref: ${{ github.ref_name }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+
     - name: Download today's schedule
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # ratchet:actions/download-artifact@v8.0.1
       with:
@@ -213,12 +181,12 @@ jobs:
     - name: Execute staggered workflows
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        STAGGER_MINUTES: ${{ needs.calculate-schedule.outputs.stagger_minutes || '5' }}
+        MAX_CONCURRENT: ${{ env.MAX_CONCURRENT_WORKFLOWS }}
       run: |
         cat > execute_schedule.sh << 'EOF'
         #!/bin/bash
 
-        STAGGER_MINUTES=5
-        MAX_CONCURRENT=3
         CURRENT_RUNNING=0
 
         echo "🚀 Starting staggered workflow execution..."
@@ -243,20 +211,23 @@ jobs:
 
           echo "📋 Triggering workflow for: $repo"
 
-          # Trigger walkthrough generation workflow
-          curl -X POST \
+          REPO_JSON=$(curl -fsS \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer $GITHUB_TOKEN" \
-            "https://api.github.com/repos/$repo/actions/workflows/generate-walkthrough.yml/dispatches" \
-            -d '{"ref":"main"}' || \
-          curl -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GITHUB_TOKEN" \
-            "https://api.github.com/repos/$repo/actions/workflows/generate-walkthrough.yml/dispatches" \
-            -d '{"ref":"master"}' || \
-            echo "⚠️ Failed to trigger workflow for $repo"
+            "https://api.github.com/repos/$repo" || echo '{}')
+          DEFAULT_BRANCH=$(echo "$REPO_JSON" | jq -r '.default_branch // "main"')
+          PAYLOAD=$(jq -n --arg ref "$DEFAULT_BRANCH" '{ref: $ref}')
 
-          echo "✅ Triggered: $repo"
+          if curl -fsS -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GITHUB_TOKEN" \
+            "https://api.github.com/repos/$repo/actions/workflows/generate-walkthrough.yml/dispatches" \
+            -d "$PAYLOAD"; then
+            echo "✅ Triggered: $repo ($DEFAULT_BRANCH)"
+          else
+            echo "⚠️ Failed to trigger workflow for $repo"
+          fi
+
           echo "⏰ Waiting $STAGGER_MINUTES minutes before next..."
           sleep $((STAGGER_MINUTES * 60))
 
@@ -270,18 +241,24 @@ jobs:
 
     - name: Update schedule status
       if: always()
+      env:
+        SCHEDULE_DATE: ${{ needs.calculate-schedule.outputs.schedule_date }}
       run: |
-        TODAY=$(date -u +%Y-%m-%d)
+        if [ -z "$SCHEDULE_DATE" ]; then
+          echo "No schedule date was executed; skipping status update"
+          exit 0
+        fi
 
         if [ -f "${{ env.SCHEDULE_FILE }}" ]; then
-          # Update today's status to completed
-          cat ${{ env.SCHEDULE_FILE }} | jq ".schedule[\"$TODAY\"].status = \"completed\" | .schedule[\"$TODAY\"].completed_at = \"$(date -u +'%Y-%m-%dT%H:%M:%SZ')\"" > temp.json
-          mv temp.json ${{ env.SCHEDULE_FILE }}
+          python src/automation/scripts/staggered_walkthrough_schedule.py complete \
+            --schedule-file "${{ env.SCHEDULE_FILE }}" \
+            --date "$SCHEDULE_DATE" \
+            --completed-at "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add ${{ env.SCHEDULE_FILE }}
-          git commit -m "chore: mark $TODAY schedule as completed [skip ci]" || echo "No changes to commit"
+          git commit -m "chore: mark $SCHEDULE_DATE schedule as completed [skip ci]" || echo "No changes to commit"
           git push || echo "No changes to push"
         fi
 

--- a/.github/workflows/staggered-scheduling.yml.meta.json
+++ b/.github/workflows/staggered-scheduling.yml.meta.json
@@ -3,7 +3,7 @@
   "name": "Staggered Scheduling for Batch Operations",
   "identifier": "urn:uuid:0a4d9035-c1c8-588d-9b5e-a75be5d99ab5",
   "version": "1.0.0",
-  "description": "General-purpose workflow. Triggered by schedule, workflow_dispatch, executes 4 job(s).",
+  "description": "Quota-aware staggered walkthrough scheduler that reuses active schedules, catches up overdue batches, and dispatches repository workflows with limited concurrency. Triggered by schedule, workflow_dispatch, executes 4 job(s).",
   "functioncalled": {
     "canonical": "logic.general.staggered.yml",
     "layer": "logic",
@@ -16,6 +16,6 @@
   "runtimePlatform": "GitHub Actions",
   "triggers": ["schedule", "workflow_dispatch"],
   "dateCreated": "2024-01-01T00:00:00Z",
-  "dateModified": "2026-01-31T00:00:00Z",
+  "dateModified": "2026-06-18T00:00:00Z",
   "dc:subject": ["general", "logic", "manual", "scheduled"]
 }

--- a/src/automation/scripts/staggered_walkthrough_schedule.py
+++ b/src/automation/scripts/staggered_walkthrough_schedule.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""Staggered walkthrough schedule planning helpers."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+COMPLETED_STATUSES = {"completed", "skipped"}
+DEFAULT_STAGGER_MINUTES = 5
+
+
+def parse_bool(value: str | bool | None) -> bool:
+    """Parse GitHub Actions boolean-like values."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def parse_iso_date(value: str | None) -> date:
+    """Parse YYYY-MM-DD dates, defaulting to the current UTC date."""
+    if not value:
+        return datetime.now(timezone.utc).date()
+    return date.fromisoformat(value)
+
+
+def utc_timestamp() -> str:
+    """Return an ISO-8601 UTC timestamp with a trailing Z."""
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def load_json(path: Path) -> Any:
+    """Load JSON from a path."""
+    with path.open() as file:
+        return json.load(file)
+
+
+def write_json(path: Path, data: Any) -> None:
+    """Write indented JSON to a path."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w") as file:
+        json.dump(data, file, indent=2)
+        file.write("\n")
+
+
+def load_schedule(path: Path) -> dict[str, Any] | None:
+    """Load a schedule file if it exists and is valid JSON."""
+    if not path.exists():
+        return None
+    data = load_json(path)
+    if not isinstance(data, dict):
+        raise ValueError(f"Schedule file must contain a JSON object: {path}")
+    return data
+
+
+def normalize_repo(repo: dict[str, Any]) -> dict[str, Any]:
+    """Normalize repository metadata used by the scheduler."""
+    full_name = str(repo.get("full_name") or repo.get("name") or "").strip()
+    if not full_name:
+        raise ValueError(f"Repository entry is missing full_name/name: {repo}")
+
+    name = str(repo.get("name") or full_name.rsplit("/", maxsplit=1)[-1])
+    size = int(repo.get("size") or 0)
+    return {
+        "name": name,
+        "full_name": full_name,
+        "size": size,
+        "default_branch": repo.get("default_branch") or "main",
+    }
+
+
+def generate_schedule(
+    repositories: list[dict[str, Any]],
+    repos_per_day: int,
+    start_date: date,
+    stagger_minutes: int = DEFAULT_STAGGER_MINUTES,
+) -> dict[str, Any]:
+    """Generate a deterministic staggered schedule from repository metadata."""
+    if repos_per_day < 1:
+        raise ValueError("repos_per_day must be at least 1")
+
+    repos = [normalize_repo(repo) for repo in repositories]
+    repos.sort(key=lambda repo: (repo["size"], repo["full_name"].lower()))
+
+    total_repos = len(repos)
+    days_needed = (total_repos + repos_per_day - 1) // repos_per_day if total_repos else 0
+    schedule: dict[str, Any] = {
+        "version": "1.1",
+        "generated_at": utc_timestamp(),
+        "repos_per_day": repos_per_day,
+        "total_repositories": total_repos,
+        "schedule_days": days_needed,
+        "schedule": {},
+    }
+
+    for day_offset in range(days_needed):
+        scheduled_date = start_date + timedelta(days=day_offset)
+        start_idx = day_offset * repos_per_day
+        end_idx = min(start_idx + repos_per_day, total_repos)
+        day_repos = repos[start_idx:end_idx]
+        date_key = scheduled_date.isoformat()
+
+        schedule["schedule"][date_key] = {
+            "date": date_key,
+            "repositories": [repo["full_name"] for repo in day_repos],
+            "count": len(day_repos),
+            "status": "pending",
+            "stagger_minutes": stagger_minutes,
+        }
+
+    return schedule
+
+
+def _is_pending_entry(entry: Any) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    repositories = entry.get("repositories") or []
+    status = str(entry.get("status") or "pending").lower()
+    return bool(repositories) and status not in COMPLETED_STATUSES
+
+
+def pending_schedule_dates(schedule: dict[str, Any]) -> list[date]:
+    """Return pending schedule dates in ascending order."""
+    entries = schedule.get("schedule") or {}
+    if not isinstance(entries, dict):
+        return []
+
+    pending_dates: list[date] = []
+    for date_text, entry in entries.items():
+        if not _is_pending_entry(entry):
+            continue
+        try:
+            pending_dates.append(date.fromisoformat(str(date_text)))
+        except ValueError:
+            continue
+
+    return sorted(pending_dates)
+
+
+def plan_schedule(
+    repositories: list[dict[str, Any]],
+    existing_schedule: dict[str, Any] | None,
+    repos_per_day: int,
+    today: date,
+    force: bool = False,
+    stagger_minutes: int = DEFAULT_STAGGER_MINUTES,
+) -> tuple[dict[str, Any], bool, str]:
+    """Reuse an active schedule or generate a new one."""
+    if force:
+        return generate_schedule(repositories, repos_per_day, today, stagger_minutes), True, "forced"
+
+    if existing_schedule and pending_schedule_dates(existing_schedule):
+        return existing_schedule, False, "active schedule has pending batches"
+
+    if existing_schedule:
+        reason = "existing schedule has no pending batches"
+    else:
+        reason = "schedule file missing"
+
+    return generate_schedule(repositories, repos_per_day, today, stagger_minutes), True, reason
+
+
+def select_due_batch(
+    schedule: dict[str, Any] | None,
+    today: date,
+) -> tuple[str | None, list[str], int]:
+    """Select the earliest pending batch due on or before today."""
+    if not schedule:
+        return None, [], DEFAULT_STAGGER_MINUTES
+
+    pending_dates = pending_schedule_dates(schedule)
+    due_dates = [scheduled_date for scheduled_date in pending_dates if scheduled_date <= today]
+    if not due_dates:
+        return None, [], DEFAULT_STAGGER_MINUTES
+
+    selected_date = min(due_dates).isoformat()
+    entry = schedule["schedule"][selected_date]
+    repositories = [str(repo) for repo in entry.get("repositories", [])]
+    stagger_minutes = int(entry.get("stagger_minutes") or DEFAULT_STAGGER_MINUTES)
+    return selected_date, repositories, stagger_minutes
+
+
+def mark_completed(
+    schedule: dict[str, Any],
+    scheduled_date: str,
+    completed_at: str | None = None,
+) -> bool:
+    """Mark a schedule date as completed."""
+    if not scheduled_date:
+        return False
+    entries = schedule.get("schedule") or {}
+    entry = entries.get(scheduled_date)
+    if not isinstance(entry, dict):
+        return False
+
+    entry["status"] = "completed"
+    entry["completed_at"] = completed_at or utc_timestamp()
+    return True
+
+
+def write_github_output(values: dict[str, Any]) -> None:
+    """Append simple key/value outputs for GitHub Actions."""
+    output_path = os.getenv("GITHUB_OUTPUT")
+    if not output_path:
+        return
+    with open(output_path, "a") as file:
+        for key, value in values.items():
+            file.write(f"{key}={value}\n")
+
+
+def command_plan(args: argparse.Namespace) -> int:
+    repositories = load_json(Path(args.repositories))
+    if not isinstance(repositories, list):
+        raise ValueError("Repository file must contain a JSON array")
+
+    schedule_path = Path(args.schedule_file)
+    try:
+        existing_schedule = load_schedule(schedule_path)
+    except (json.JSONDecodeError, ValueError) as exc:
+        print(f"Ignoring invalid existing schedule: {exc}")
+        existing_schedule = None
+
+    today = parse_iso_date(args.today)
+    repos_per_day = int(args.repos_per_day)
+    force = parse_bool(args.force)
+
+    schedule, regenerated, reason = plan_schedule(
+        repositories,
+        existing_schedule,
+        repos_per_day,
+        today,
+        force=force,
+        stagger_minutes=int(args.stagger_minutes),
+    )
+    write_json(Path(args.output), schedule)
+
+    print(f"Schedule regenerated: {str(regenerated).lower()} ({reason})")
+    print(f"Total repositories: {schedule.get('total_repositories', 0)}")
+    print(f"Schedule days: {schedule.get('schedule_days', 0)}")
+
+    write_github_output(
+        {
+            "has_schedule": "true",
+            "schedule_regenerated": str(regenerated).lower(),
+            "schedule_days": schedule.get("schedule_days", 0),
+            "total_repositories": schedule.get("total_repositories", 0),
+        }
+    )
+    return 0
+
+
+def command_due(args: argparse.Namespace) -> int:
+    schedule = load_schedule(Path(args.schedule_file))
+    today = parse_iso_date(args.today)
+    scheduled_date, repositories, stagger_minutes = select_due_batch(schedule, today)
+
+    repos_output = Path(args.repos_output)
+    repos_output.write_text("\n".join(repositories) + ("\n" if repositories else ""))
+
+    if repositories:
+        print(f"Selected schedule date: {scheduled_date}")
+        print(f"Repositories due: {len(repositories)}")
+    else:
+        print("No repositories are due for execution")
+
+    write_github_output(
+        {
+            "repos_today": len(repositories),
+            "schedule_date": scheduled_date or "",
+            "stagger_minutes": stagger_minutes,
+        }
+    )
+    return 0
+
+
+def command_complete(args: argparse.Namespace) -> int:
+    schedule_path = Path(args.schedule_file)
+    schedule = load_schedule(schedule_path)
+    if not schedule:
+        print("No schedule found; nothing to mark complete")
+        return 0
+
+    changed = mark_completed(schedule, args.date, args.completed_at)
+    if changed:
+        write_json(schedule_path, schedule)
+        print(f"Marked schedule date complete: {args.date}")
+    else:
+        print(f"Schedule date not found: {args.date}")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    plan = subparsers.add_parser("plan", help="Generate or reuse a staggered schedule")
+    plan.add_argument("--repositories", required=True)
+    plan.add_argument("--schedule-file", required=True)
+    plan.add_argument("--output", required=True)
+    plan.add_argument("--repos-per-day", required=True)
+    plan.add_argument("--today")
+    plan.add_argument("--force", default="false")
+    plan.add_argument("--stagger-minutes", default=str(DEFAULT_STAGGER_MINUTES))
+    plan.set_defaults(func=command_plan)
+
+    due = subparsers.add_parser("due", help="Write repositories due for execution")
+    due.add_argument("--schedule-file", required=True)
+    due.add_argument("--repos-output", required=True)
+    due.add_argument("--today")
+    due.set_defaults(func=command_due)
+
+    complete = subparsers.add_parser("complete", help="Mark a schedule date complete")
+    complete.add_argument("--schedule-file", required=True)
+    complete.add_argument("--date", required=True)
+    complete.add_argument("--completed-at")
+    complete.set_defaults(func=command_complete)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_staggered_walkthrough_schedule.py
+++ b/tests/unit/test_staggered_walkthrough_schedule.py
@@ -1,0 +1,89 @@
+"""Tests for staggered walkthrough schedule planning."""
+
+from datetime import date
+
+import pytest
+
+from src.automation.scripts.staggered_walkthrough_schedule import (
+    generate_schedule,
+    mark_completed,
+    plan_schedule,
+    select_due_batch,
+)
+
+
+@pytest.fixture
+def repositories():
+    return [
+        {"name": "large-app", "full_name": "organvm/large-app", "size": 500},
+        {"name": "small-app", "full_name": "organvm/small-app", "size": 10},
+        {"name": "medium-app", "full_name": "organvm/medium-app", "size": 100},
+    ]
+
+
+@pytest.mark.unit
+def test_generate_schedule_distributes_repositories_by_day(repositories):
+    schedule = generate_schedule(repositories, repos_per_day=2, start_date=date(2026, 6, 1))
+
+    assert schedule["schedule_days"] == 2
+    assert schedule["schedule"]["2026-06-01"]["repositories"] == [
+        "organvm/small-app",
+        "organvm/medium-app",
+    ]
+    assert schedule["schedule"]["2026-06-02"]["repositories"] == ["organvm/large-app"]
+
+
+@pytest.mark.unit
+def test_plan_schedule_reuses_active_schedule_instead_of_rolling_forward(repositories):
+    existing = generate_schedule(repositories, repos_per_day=1, start_date=date(2026, 6, 1))
+
+    planned, regenerated, reason = plan_schedule(
+        repositories,
+        existing,
+        repos_per_day=1,
+        today=date(2026, 6, 2),
+    )
+
+    assert regenerated is False
+    assert "pending batches" in reason
+    assert planned["schedule"].keys() == existing["schedule"].keys()
+    assert "2026-06-01" in planned["schedule"]
+
+
+@pytest.mark.unit
+def test_plan_schedule_regenerates_after_all_batches_complete(repositories):
+    existing = generate_schedule(repositories, repos_per_day=3, start_date=date(2026, 6, 1))
+    mark_completed(existing, "2026-06-01", "2026-06-01T01:00:00Z")
+
+    planned, regenerated, reason = plan_schedule(
+        repositories,
+        existing,
+        repos_per_day=3,
+        today=date(2026, 6, 8),
+    )
+
+    assert regenerated is True
+    assert reason == "existing schedule has no pending batches"
+    assert list(planned["schedule"]) == ["2026-06-08"]
+
+
+@pytest.mark.unit
+def test_select_due_batch_catches_up_oldest_pending_batch(repositories):
+    schedule = generate_schedule(repositories, repos_per_day=1, start_date=date(2026, 6, 1))
+
+    scheduled_date, due_repositories, stagger_minutes = select_due_batch(schedule, date(2026, 6, 3))
+
+    assert scheduled_date == "2026-06-01"
+    assert due_repositories == ["organvm/small-app"]
+    assert stagger_minutes == 5
+
+
+@pytest.mark.unit
+def test_mark_completed_updates_selected_date(repositories):
+    schedule = generate_schedule(repositories, repos_per_day=1, start_date=date(2026, 6, 1))
+
+    changed = mark_completed(schedule, "2026-06-01", "2026-06-01T01:00:00Z")
+
+    assert changed is True
+    assert schedule["schedule"]["2026-06-01"]["status"] == "completed"
+    assert schedule["schedule"]["2026-06-01"]["completed_at"] == "2026-06-01T01:00:00Z"


### PR DESCRIPTION
Autonomous **limen** dispatch of task `RESOLVE-organvm-i-theoria-.github-457`.

Resolve blocked PR organvm-i-theoria/.github#457 ('[limen GH-organvm-i-theoria-github-451] 🚨 Security Alert: Po'), state=BLOCKED. Branch=limen/gh-organvm-i-theoria-github-451-fd3b, base=main. In the worktree: `git fetch origin limen/gh-organvm-i-theoria-github-451-fd3b main; git checkout -B limen/gh-organvm-i-theoria-github-451-fd3b origin/limen/gh-organvm-i-theoria-github-451-fd3b; git rebase origin/main` then address the failing checks / unresolved review threads; run the build/tests; `git push --force-with-lease origin limen/gh-organvm-i-theoria-github-451-fd3b`. If the branch is unrecoverable, instead REBUILD the same feature cleanly off origin/main as a fresh PR. Goal: make it mergeable.

_Produced in an isolated worktree off origin — review before merge._

## Summary by Sourcery

Introduce a reusable Python-based scheduler for staggered walkthrough workflows and integrate it into the existing GitHub Actions pipeline.

New Features:
- Add a Python CLI utility to generate, select, and complete staggered walkthrough schedules, with GitHub Actions–friendly outputs.

Enhancements:
- Refactor the staggered scheduling workflow to delegate planning, due-batch selection, and completion updates to the new scheduler script while making schedule commits conditional on actual changes.
- Parameterize stagger interval and concurrency in the execution job and use each repository’s default branch when dispatching walkthrough workflows.

Tests:
- Add unit tests covering schedule generation, reuse and regeneration logic, due-batch selection, and completion marking in the new scheduler.