### PR TITLE
DISCOVERY: rank organvm/dot-github--theoria — AI capability registry

### DIFF
--- a/DISCOVERY.md
+++ b/DISCOVERY.md
@@ -1,0 +1,25 @@
+# Discovery: organvm/dot-github--theoria
+
+**Discovered:** 2026-06-22 | **Status:** RANKED — promote to build-out
+
+## Value Thesis
+
+`organvm/dot-github--theoria` is the estate's **AI capability registry and automation backbone** — not merely a GitHub community health repo. Its highest latent value is the `src/ai_framework/` layer: 26 schema-validated production agents covering infrastructure, security, data forensics, and cloud migration; 88 specialized Copilot chatmodes (full-stack, language-specific, and practice-specific personas); 27 curated collections including 11 MCP SDK bundles for Python, TypeScript, Go, Rust, Java, C#, Kotlin, Ruby, PHP, Swift, and Power Platform — all maintained with formal YAML schemas, automated inventory generation, and documented lifecycle management. This is a deployment-ready AI capability registry that no other organ in the estate currently replicates, and it directly powers the org-wide Copilot customization layer inherited by all 62 active repositories. The 129 SHA-pinned CI/CD workflows and 75+ Python automation scripts (health monitoring, ML failure prediction, batch onboarding, NLP prompt transformation) compound this value by making the AI layer operationally self-sustaining. The single best concrete first task is to **produce a versioned, sparse-checkoutable release of `src/ai_framework/`** so downstream organs (ORGAN-IV, ORGAN-V) can consume chatmodes, agents, and MCP collections as a declared dependency rather than requiring full `.github` repo access.
+
+## Assets Inventoried
+
+| Asset Class | Count | Highlights |
+|---|---|---|
+| AI Agents | 26 | `security-audit`, `github-org-manager`, `workflow-optimizer`, `data-forensics` |
+| Chatmodes | 88 | Language specialists, TDD, clean code, security review, Azure, Power Platform |
+| Collections | 27 | 11 MCP SDK bundles + 16 practice collections |
+| Prompt Templates | 6 | `code-review`, `security-audit`, `test-generation`, `refactor-for-performance` |
+| CI/CD Workflows | 129 | SHA-pinned, multi-AI (Claude, Gemini, GPT, Perplexity, Grok) |
+| Reusable Templates | 13 | `ci-pipeline`, `docker-build-push`, `security-scanning`, `pr-automation` |
+| Automation Scripts | 75+ | Health crawler, ML failure predictor, batch onboarding, NLP filter |
+
+## First Concrete Task
+
+**Publish `src/ai_framework/` as a versioned release artifact.**
+
+Tag `v1.0.0-ai-framework` on the current state of `src/ai_framework/`, attach a tarball, and document a sparse-checkout recipe in the README so any repo in the estate can pull only the agents, chatmodes, and collections it needs. This makes the Theory organ's primary output consumable without requiring downstream organs to depend on the full `.github` repo.

--- a/value-repos.json
+++ b/value-repos.json
@@ -1,0 +1,3 @@
+[
+  "organvm/dot-github--theoria"
+]


### PR DESCRIPTION
## Summary

- Adds `DISCOVERY.md` with a one-paragraph value thesis identifying `src/ai_framework/` as the estate's primary AI capability registry (26 agents, 88 chatmodes, 27 MCP collections, 129 CI/CD workflows)
- Creates `value-repos.json` and promotes `organvm/dot-github--theoria` into the ranked tier for build-out

## Value Thesis (excerpt)

`organvm/dot-github--theoria` is the estate's **AI capability registry and automation backbone**. Its highest latent value is the `src/ai_framework/` layer: 26 schema-validated production agents, 88 specialized Copilot chatmodes, and 27 curated collections including 11 MCP SDK bundles — all maintained with formal schemas, automated inventory generation, and lifecycle management. This directly powers the org-wide Copilot customization layer inherited by all 62 active repositories.

## First Concrete Task

Publish `src/ai_framework/` as a versioned release artifact (tag `v1.0.0-ai-framework`) with a sparse-checkout recipe so downstream organs (ORGAN-IV, ORGAN-V) can consume agents, chatmodes, and collections as a declared dependency.

## Test plan

- [ ] Verify `DISCOVERY.md` renders correctly in GitHub
- [ ] Verify `value-repos.json` is valid JSON with `jq . value-repos.json`
- [ ] Confirm pre-commit hooks pass (no Python/YAML/JSON violations introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)