### PR TITLE
[limen HEAL-cifix-organvm-dot-github--theoria-470] fix failing CI on organvm/dot-github--theoria#470

### DIFF
--- a/logs/agents/opencode.json
+++ b/logs/agents/opencode.json
@@ -1,0 +1,11 @@
+{
+  "agent": "opencode",
+  "status": "idle",
+  "accepting_tasks": true,
+  "available_tokens": 39252799,
+  "available_pct": 78.5,
+  "current_task_id": "HEAL-cifix-organvm-dot-github--theoria-470",
+  "heartbeat": "2026-07-05T19:39:22.550480+00:00",
+  "token_usage_pct": 21.49,
+  "clock_health": "ok"
+}


### PR DESCRIPTION
Autonomous **limen** dispatch of task `HEAL-cifix-organvm-dot-github--theoria-470`.

PR organvm/dot-github--theoria#470 has FAILING CI checks and merge-drain correctly refuses to merge it. Check out the PR branch, find the root cause of the red checks (lint / types / failing test / config), fix it, push to the SAME PR branch, and confirm every check goes green. Do not open a new PR — repair the existing one so merge-drain lands it. PR: https://github.com/organvm/dot-github--theoria/pull/470 [auto-emitted 2026-07-04 by self-heal so merge-drain can land it]

Refs: https://github.com/organvm/dot-github--theoria/pull/470

_Produced in an isolated worktree off origin — review before merge._