### PR TITLE
fix(ci): remove orphaned agent worktree gitlink

### DIFF
--- a/.github/workflows/demo-deployment.yml
+++ b/.github/workflows/demo-deployment.yml
@@ -13,6 +13,7 @@ on:
     - Dockerfile
     - docker-compose.yml
     - .github/workflows/demo-deployment.yml
+    - .github/workflows/demo-sandbox-reusable.yml
   workflow_dispatch:
     inputs:
       app-type:

--- a/.github/workflows/demo-sandbox-reusable.yml
+++ b/.github/workflows/demo-sandbox-reusable.yml
@@ -476,29 +476,11 @@ jobs:
       env:
         REPO: ${{ github.repository }}
         REF: ${{ github.ref_name }}
-      run: |2
-
-        # Create demo-specific devcontainer if it doesn't exist
-        mkdir -p .devcontainer/demo
-        cat > .devcontainer/demo/devcontainer.json << 'DEVCONTAINER'
-        {
-          "name": "Demo Sandbox",
-          "image": "mcr.microsoft.com/devcontainers/universal:2",
-          "features": {
-            "ghcr.io/devcontainers/features/node:1": {},
-            "ghcr.io/devcontainers/features/python:1": {}
-          },
-          "containerEnv": {
-            "DEMO_MODE": "true",
-            "DEMO_BANNER": "true",
-            "DEMO_AUTH_BYPASS": "true"
-          },
-          "postCreateCommand": "echo 'Demo sandbox ready'",
-          "forwardPorts": [3000, 5000, 8000, 8080]
-        }
-        DEVCONTAINER
-
-        DEEP_LINK="https://codespaces.new/${REPO}?ref=${REF}&devcontainer_path=.devcontainer/demo/devcontainer.json"
+      run: |
+        DEEP_LINK="https://codespaces.new/${REPO}?ref=${REF}"
+        if [ -f ".devcontainer/demo/devcontainer.json" ]; then
+          DEEP_LINK="${DEEP_LINK}&devcontainer_path=.devcontainer/demo/devcontainer.json"
+        fi
 
         echo "url=$DEEP_LINK" >> "$GITHUB_OUTPUT"
         echo "Codespaces deep link: $DEEP_LINK"

--- a/.github/workflows/demo-sandbox-reusable.yml
+++ b/.github/workflows/demo-sandbox-reusable.yml
@@ -573,34 +573,46 @@ jobs:
           echo "No README.md found, skipping badge injection"
           exit 0
         fi
-        BADGE="[![Try Demo](https://img.shields.io/badge/Try%20Demo-Live%20Sandbox-brightgreen?style=${STYLE})](${SANDBOX_URL})"
+        python3 - <<'PY'
+        import os
+        from pathlib import Path
 
-        MARKER_START="<!-- DEMO:START -->"
-        MARKER_END="<!-- DEMO:END -->"
+        path = Path("README.md")
+        text = path.read_text(encoding="utf-8")
+        marker_start = "<!-- DEMO:START -->"
+        marker_end = "<!-- DEMO:END -->"
+        badge = (
+            "[![Try Demo](https://img.shields.io/badge/"
+            f"Try%20Demo-Live%20Sandbox-brightgreen?style={os.environ['STYLE']})]"
+            f"({os.environ['SANDBOX_URL']})"
+        )
+        block = f"{marker_start}\n\n{badge}\n\n{marker_end}"
 
-        if grep -q "$MARKER_START" README.md; then
-          # Replace content between markers (idempotent)
-          sed -i "/$MARKER_START/,/$MARKER_END/c\\$MARKER_START\n$BADGE\n$MARKER_END" README.md
-        elif grep -q "^# " README.md; then
-          # Insert after the first heading
-          sed -i "0,/^# /{s|^\(# .*\)|\1\n\n$MARKER_START\n$BADGE\n$MARKER_END|}" README.md
-        else
-          # Prepend to file
-          {
-            echo "$MARKER_START"
-            echo "$BADGE"
-            echo "$MARKER_END"
-            echo ""
-            cat README.md
-          } > README.md.tmp && mv README.md.tmp README.md
-        fi
+        if marker_start in text:
+            if marker_end not in text:
+                raise SystemExit("README has an opening demo marker without a closing marker")
+            before, remainder = text.split(marker_start, 1)
+            _, after = remainder.split(marker_end, 1)
+            updated = f"{before}{block}{after}"
+        else:
+            lines = text.splitlines(keepends=True)
+            heading = next((index for index, line in enumerate(lines) if line.startswith("# ")), None)
+            if heading is None:
+                updated = f"{block}\n\n{text}"
+            else:
+                lines.insert(heading + 1, f"\n{block}\n")
+                updated = "".join(lines)
+
+        if updated != text:
+            path.write_text(updated, encoding="utf-8")
+        PY
 
     - name: Create pull request
       uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c  # ratchet:peter-evans/create-pull-request@v6
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: 'feat: add "Try Demo" sandbox badge to README'
-        title: Add "Try Demo" sandbox badge
+        commit-message: 'feat(demo): add Try Demo sandbox badge'
+        title: 'feat(demo): add Try Demo sandbox badge'
         body: |
           ## Demo Sandbox Badge
 
@@ -615,7 +627,7 @@ jobs:
 
           ---
           _Automated by the [demo-sandbox](.github/workflows/demo-sandbox-reusable.yml) reusable workflow._
-        branch: demo/add-sandbox-badge
+        branch: maintenance/chore/demo-sandbox-badge
         delete-branch: true
 
   # ──────────────────────────────────────────────────────────────────────

--- a/.github/workflows/demo-sandbox-reusable.yml
+++ b/.github/workflows/demo-sandbox-reusable.yml
@@ -478,7 +478,7 @@ jobs:
         REF: ${{ github.ref_name }}
       run: |
         DEEP_LINK="https://codespaces.new/${REPO}?ref=${REF}"
-        if [ -f ".devcontainer/demo/devcontainer.json" ]; then
+        if git cat-file -e "HEAD:.devcontainer/demo/devcontainer.json" 2>/dev/null; then
           DEEP_LINK="${DEEP_LINK}&devcontainer_path=.devcontainer/demo/devcontainer.json"
         fi
 
@@ -593,8 +593,8 @@ jobs:
       uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c  # ratchet:peter-evans/create-pull-request@v6
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
-        commit-message: 'feat(demo): add Try Demo sandbox badge'
-        title: 'feat(demo): add Try Demo sandbox badge'
+        commit-message: 'feat(workflows): add Try Demo sandbox badge'
+        title: 'feat(workflows): add Try Demo sandbox badge'
         body: |
           ## Demo Sandbox Badge
 

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ generated_workflows/
 
 # Local tool configuration
 .serena/
+/.claude/worktrees/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,12 @@
 
 # .github
 
+<!-- DEMO:START -->
+
+[![Try Demo](https://img.shields.io/badge/Try%20Demo-Live%20Sandbox-brightgreen?style=for-the-badge)](https://codespaces.new/organvm/dot-github--theoria?ref=main&devcontainer_path=.devcontainer/demo/devcontainer.json)
+
+<!-- DEMO:END -->
+
 **Organization-wide infrastructure for CI/CD, AI agents, and community health**
 
 <!-- BADGES:START -->

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <!-- DEMO:START -->
 
-[![Try Demo](https://img.shields.io/badge/Try%20Demo-Live%20Sandbox-brightgreen?style=for-the-badge)](https://codespaces.new/organvm/dot-github--theoria?ref=main&devcontainer_path=.devcontainer/demo/devcontainer.json)
+[![Try Demo](https://img.shields.io/badge/Try%20Demo-Live%20Sandbox-brightgreen?style=for-the-badge)](https://codespaces.new/organvm/dot-github--theoria?ref=main)
 
 <!-- DEMO:END -->
 

--- a/docs/registry/workflow-registry.json
+++ b/docs/registry/workflow-registry.json
@@ -1190,7 +1190,7 @@
       "name": "Demo Sandbox (Reusable)",
       "path": "demo-sandbox-reusable.yml",
       "meta": "demo-sandbox-reusable.yml.meta.json",
-      "hash": "37a6bd445e05708fbd18303c5c6896597d9f8cb13d0b7d193ccab5310a6b54f4",
+      "hash": "4b9e982ede84679f72ece5eed7787ff37190ffc66f31155d917ff46608edcfb0",
       "functioncalled": {
         "canonical": "core.deployment.demo-sandbox.yml",
         "layer": "core",

--- a/docs/registry/workflow-registry.json
+++ b/docs/registry/workflow-registry.json
@@ -479,7 +479,7 @@
       "name": "Demo Sandbox Deployment",
       "path": "demo-deployment.yml",
       "meta": "demo-deployment.yml.meta.json",
-      "hash": "25114ce8923d3759719e5eef0797651f51ce7bb5f8dc3f73edbb9c036a6ff2a3",
+      "hash": "58606e762bca99a0dc3a917b9ca0ee6fec477b0ff10f0d4862ee87e0e5777d30",
       "functioncalled": {
         "canonical": "application.deployment.demo-sandbox.yml",
         "layer": "application",

--- a/docs/registry/workflow-registry.json
+++ b/docs/registry/workflow-registry.json
@@ -1190,7 +1190,7 @@
       "name": "Demo Sandbox (Reusable)",
       "path": "demo-sandbox-reusable.yml",
       "meta": "demo-sandbox-reusable.yml.meta.json",
-      "hash": "4686d220b3d85782550f4c3e108cc50614053f1cfc305ad76142eca34b4615fd",
+      "hash": "37a6bd445e05708fbd18303c5c6896597d9f8cb13d0b7d193ccab5310a6b54f4",
       "functioncalled": {
         "canonical": "core.deployment.demo-sandbox.yml",
         "layer": "core",

--- a/docs/registry/workflow-registry.json
+++ b/docs/registry/workflow-registry.json
@@ -1190,7 +1190,7 @@
       "name": "Demo Sandbox (Reusable)",
       "path": "demo-sandbox-reusable.yml",
       "meta": "demo-sandbox-reusable.yml.meta.json",
-      "hash": "4b9e982ede84679f72ece5eed7787ff37190ffc66f31155d917ff46608edcfb0",
+      "hash": "01647a74362211883762b0252c5cc746e33aaaaf8545fb49cdb49fa427e29f11",
       "functioncalled": {
         "canonical": "core.deployment.demo-sandbox.yml",
         "layer": "core",

--- a/tests/unit/test_workflow_policy_contracts.py
+++ b/tests/unit/test_workflow_policy_contracts.py
@@ -2,6 +2,7 @@
 
 import json
 import re
+import subprocess
 from pathlib import Path
 
 import yaml
@@ -120,6 +121,20 @@ def test_batch_pr_outputs_enter_github_script_through_environment():
 def test_volatile_agent_logs_are_local_runtime_state():
     """Ephemeral agent heartbeats cannot become product diffs."""
     assert "/logs/agents/" in read(ROOT / ".gitignore")
+
+
+def test_agent_worktrees_are_local_runtime_state():
+    """Agent worktrees must never be committed as orphaned gitlinks."""
+    assert "/.claude/worktrees/" in read(ROOT / ".gitignore")
+
+    tracked = subprocess.run(
+        ["git", "ls-files", "--stage", "--", ".claude/worktrees"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert tracked.stdout == ""
 
 
 def test_dependency_review_uses_supported_action_inputs():

--- a/tests/unit/test_workflow_policy_contracts.py
+++ b/tests/unit/test_workflow_policy_contracts.py
@@ -154,6 +154,7 @@ def test_demo_push_and_manual_inputs_preserve_reusable_workflow_types():
     """Push defaults and manual booleans must remain correctly typed at the call boundary."""
     workflow = read(WORKFLOWS / "demo-deployment.yml")
 
+    assert "- .github/workflows/demo-sandbox-reusable.yml" in workflow
     assert "uses: ./.github/workflows/demo-sandbox-reusable.yml" in workflow
     assert "uses: ./.github/workflows/reusable/" not in workflow
     assert "github.event.inputs['app-type']" in workflow

--- a/tests/unit/test_workflow_policy_contracts.py
+++ b/tests/unit/test_workflow_policy_contracts.py
@@ -186,6 +186,35 @@ def test_demo_badge_injection_preserves_query_parameters_and_is_idempotent(tmp_p
     assert readme.read_bytes() == first
 
 
+def test_codespaces_url_only_names_repository_owned_devcontainers(tmp_path: Path):
+    """A disposable runner file must never appear in the durable Codespaces URL."""
+    workflow = yaml.safe_load(read(WORKFLOWS / "demo-sandbox-reusable.yml"))
+    script = next(
+        step["run"]
+        for step in workflow["jobs"]["deploy"]["steps"]
+        if step.get("name") == "Generate Codespaces deep link"
+    )
+    output = tmp_path / "github-output"
+    env = {
+        **os.environ,
+        "GITHUB_OUTPUT": str(output),
+        "REPO": "organvm/example",
+        "REF": "main",
+    }
+
+    subprocess.run(["bash", "-eu", "-o", "pipefail", "-c", script], cwd=tmp_path, env=env, check=True)
+    assert output.read_text(encoding="utf-8") == "url=https://codespaces.new/organvm/example?ref=main\n"
+
+    devcontainer = tmp_path / ".devcontainer" / "demo" / "devcontainer.json"
+    devcontainer.parent.mkdir(parents=True)
+    devcontainer.write_text("{}\n", encoding="utf-8")
+    output.unlink()
+    subprocess.run(["bash", "-eu", "-o", "pipefail", "-c", script], cwd=tmp_path, env=env, check=True)
+    assert output.read_text(encoding="utf-8") == (
+        "url=https://codespaces.new/organvm/example?ref=main&devcontainer_path=.devcontainer/demo/devcontainer.json\n"
+    )
+
+
 def test_required_checks_run_on_merge_queue_without_publishing_images():
     """Every required-check owner must emit on merge_group without deployment side effects."""
     required_check_workflows = [

--- a/tests/unit/test_workflow_policy_contracts.py
+++ b/tests/unit/test_workflow_policy_contracts.py
@@ -1,6 +1,7 @@
 """Regression tests for repository-owned workflow policy contracts."""
 
 import json
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -83,6 +84,10 @@ def test_repo_owned_pr_producers_emit_compliant_metadata():
             'BRANCH="maintenance/chore/dependency-updates-',
             '--title "chore(deps): update dependencies"',
         ],
+        WORKFLOWS / "demo-sandbox-reusable.yml": [
+            "branch: maintenance/chore/demo-sandbox-badge",
+            "title: 'feat(demo): add Try Demo sandbox badge'",
+        ],
         WORKFLOWS / "reusable" / "pr-batching.yml": [
             "default: maintenance/chore/",
             "title: `chore(automation): batch ${included.length} pull requests`,",
@@ -159,6 +164,25 @@ def test_demo_push_and_manual_inputs_preserve_reusable_workflow_types():
     assert "${{ inputs.app-type" not in workflow
     assert "${{ inputs.hosting-provider" not in workflow
     assert "&& github.event.inputs['inject-badge'] || true" not in workflow
+
+
+def test_demo_badge_injection_preserves_query_parameters_and_is_idempotent(tmp_path: Path):
+    """Badge insertion must not treat ampersands in the sandbox URL as sed replacements."""
+    workflow = yaml.safe_load(read(WORKFLOWS / "demo-sandbox-reusable.yml"))
+    script = next(
+        step["run"] for step in workflow["jobs"]["badge"]["steps"] if step.get("name") == "Inject badge into README"
+    )
+    readme = tmp_path / "README.md"
+    readme.write_text("# Demo\n\nBody\n", encoding="utf-8")
+    url = "https://codespaces.new/organvm/example?ref=main&devcontainer_path=.devcontainer/demo/devcontainer.json"
+    env = {**os.environ, "SANDBOX_URL": url, "STYLE": "for-the-badge"}
+
+    subprocess.run(["bash", "-eu", "-o", "pipefail", "-c", script], cwd=tmp_path, env=env, check=True)
+    first = readme.read_bytes()
+    subprocess.run(["bash", "-eu", "-o", "pipefail", "-c", script], cwd=tmp_path, env=env, check=True)
+
+    assert f"]({url})" in first.decode("utf-8")
+    assert readme.read_bytes() == first
 
 
 def test_required_checks_run_on_merge_queue_without_publishing_images():

--- a/tests/unit/test_workflow_policy_contracts.py
+++ b/tests/unit/test_workflow_policy_contracts.py
@@ -86,7 +86,7 @@ def test_repo_owned_pr_producers_emit_compliant_metadata():
         ],
         WORKFLOWS / "demo-sandbox-reusable.yml": [
             "branch: maintenance/chore/demo-sandbox-badge",
-            "title: 'feat(demo): add Try Demo sandbox badge'",
+            "title: 'feat(workflows): add Try Demo sandbox badge'",
         ],
         WORKFLOWS / "reusable" / "pr-batching.yml": [
             "default: maintenance/chore/",
@@ -202,12 +202,26 @@ def test_codespaces_url_only_names_repository_owned_devcontainers(tmp_path: Path
         "REF": "main",
     }
 
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=tmp_path, check=True)
+    readme = tmp_path / "README.md"
+    readme.write_text("# Demo\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "test: establish repository head"], cwd=tmp_path, check=True)
+
     subprocess.run(["bash", "-eu", "-o", "pipefail", "-c", script], cwd=tmp_path, env=env, check=True)
     assert output.read_text(encoding="utf-8") == "url=https://codespaces.new/organvm/example?ref=main\n"
 
     devcontainer = tmp_path / ".devcontainer" / "demo" / "devcontainer.json"
     devcontainer.parent.mkdir(parents=True)
     devcontainer.write_text("{}\n", encoding="utf-8")
+    output.unlink()
+    subprocess.run(["bash", "-eu", "-o", "pipefail", "-c", script], cwd=tmp_path, env=env, check=True)
+    assert output.read_text(encoding="utf-8") == "url=https://codespaces.new/organvm/example?ref=main\n"
+
+    subprocess.run(["git", "add", ".devcontainer/demo/devcontainer.json"], cwd=tmp_path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "test: add demo devcontainer"], cwd=tmp_path, check=True)
     output.unlink()
     subprocess.run(["bash", "-eu", "-o", "pipefail", "-c", script], cwd=tmp_path, env=env, check=True)
     assert output.read_text(encoding="utf-8") == (


### PR DESCRIPTION
## Outcome

Repairs both failures exposed by the exact main push after #503:

1. Removes the orphaned tracked agent-worktree gitlink that makes actions/checkout cleanup fail before Semantic Release can run.
2. Repairs the Demo sandbox contract end to end: valid and idempotent README badge mutation, compliant automation metadata, a durable Codespaces URL derived only from files actually present in the repository, and push coverage whenever the reusable workflow changes.

## Gitlink custody proof

- Detached target: efff71cb1ad154a65d5099e45bd186afe3444e6f
- The target is reachable on the remote and is an ancestor of origin/main at 62a8f0864e784ea7e469528bc9a9d56333206d4d.
- Remote custody: https://github.com/organvm/dot-github--theoria/commit/efff71cb1ad154a65d5099e45bd186afe3444e6f
- The tracked entry was only a gitlink reference; its checkout directory was empty and no unique payload was removed.

## Demo custody proof

- Failed main run: https://github.com/organvm/dot-github--theoria/actions/runs/29203572112
- Generated branch commit whose intent is preserved here: 1d1804cbd7a9b944eda890d258a1cd0c6b0c644f
- The generated sed output corrupted the ampersand-bearing Codespaces URL, Actions was forbidden by organization policy from opening its PR, and its advertised devcontainer existed only in a disposable runner.
- This PR lands a corrected badge directly, removes the runner-only path claim, and adds behavioral regressions for exact URL preservation, repository-owned devcontainer selection, generic fallback, and byte-identical reruns.

## Verification

- Focused policy suite: 15 passed
- actionlint on both Demo workflows: passed
- Pre-commit on changed source files: passed, with managed-link rewriting intentionally skipped because it mutates unrelated documentation; the registry's known hash-only detect-secrets false positives were independently scoped.
- Workflow registry SHA-256 values match both changed Demo workflows.
- git diff --check: passed

## Merge condition

All required exact-head checks pass, merge-queue checks pass, and Semantic Release plus Demo Sandbox are green on the resulting main SHA.
