### PR TITLE
fix(workflows): the schedule push targeted protected main, so the job failed every run

### DIFF
--- a/.github/scripts/publish-schedule-state.sh
+++ b/.github/scripts/publish-schedule-state.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# publish-schedule-state.sh — persist the staggered schedule WITHOUT pushing to protected `main`.
+#
+# THE DEFECT THIS REPLACES. `staggered-scheduling.yml` committed the schedule and ran a bare
+# `git push` at two sites. `main` is protected behind a merge queue with 8 required checks, so
+# every push was rejected — `GH006: Protected branch update failed ... Changes must be made
+# through the merge queue` — and the "Save schedule" step had no fail-open guard, so the job
+# failed on EVERY scheduled run and would have forever. The second site (`Update schedule
+# status`) was already tolerant (`git push || echo ...`), so it failed silently instead: the
+# same defect, only quieter.
+#
+# WHY A BRANCH AND NOT THE MERGE QUEUE. The schedule is cross-run automation state, not
+# reviewable source. Routing a daily bot commit through a queue with 8 required checks would
+# spend CI on a machine-written JSON file and pile up an unmergeable PR per day. State belongs
+# on its own unprotected branch.
+#
+# WHY THE CONTENTS API AND NOT `git push`. Publishing to another branch with git would mean
+# checking it out, which swaps the working tree out from under the later steps that still need
+# `src/automation/scripts/` and `repos_today.txt`. The Contents API writes a branch without
+# touching the checkout at all. `contents: write` is already granted by the workflow.
+#
+#   publish-schedule-state.sh <file> <branch> <commit-message>
+set -euo pipefail
+
+FILE="${1:?schedule file required}"
+BRANCH="${2:?state branch required}"
+MESSAGE="${3:?commit message required}"
+REPO="${GITHUB_REPOSITORY:?GITHUB_REPOSITORY required}"
+API="${GITHUB_API_URL:-https://api.github.com}"
+DEFAULT_BRANCH="${GITHUB_DEFAULT_BRANCH:-main}"
+
+if [ ! -f "$FILE" ]; then
+  echo "publish-schedule-state: $FILE does not exist — nothing to publish"
+  exit 0
+fi
+
+AUTH=(-H "Accept: application/vnd.github+json" -H "Authorization: Bearer ${GITHUB_TOKEN:?GITHUB_TOKEN required}")
+
+# Create the state branch off the default branch on first use.
+if ! curl -fsS "${AUTH[@]}" "$API/repos/$REPO/git/ref/heads/$BRANCH" >/dev/null 2>&1; then
+  base_sha=$(curl -fsS "${AUTH[@]}" "$API/repos/$REPO/git/ref/heads/$DEFAULT_BRANCH" | jq -r '.object.sha')
+  curl -fsS -X POST "${AUTH[@]}" "$API/repos/$REPO/git/refs" \
+    -d "$(jq -n --arg ref "refs/heads/$BRANCH" --arg sha "$base_sha" '{ref: $ref, sha: $sha}')" >/dev/null
+  echo "created state branch $BRANCH"
+fi
+
+# The blob sha is REQUIRED to update an existing file and must be OMITTED to create one —
+# sending an empty sha is a 422, so the payload is built conditionally below.
+existing=$(curl -fsS "${AUTH[@]}" "$API/repos/$REPO/contents/$FILE?ref=$BRANCH" 2>/dev/null || echo '{}')
+existing_sha=$(printf '%s' "$existing" | jq -r '.sha // empty')
+
+# Skip a no-op write so the branch does not accumulate an empty commit per day.
+if [ -n "$existing_sha" ]; then
+  remote=$(printf '%s' "$existing" | jq -r '.content // empty' | tr -d '\n' | base64 --decode 2>/dev/null || true)
+  if [ "$remote" = "$(cat "$FILE")" ]; then
+    echo "schedule unchanged — nothing to publish"
+    exit 0
+  fi
+fi
+
+# base64 -w0 is GNU; macOS/BSD base64 has no -w and already emits a single line.
+encoded=$(base64 -w0 < "$FILE" 2>/dev/null || base64 < "$FILE" | tr -d '\n')
+
+payload=$(jq -n \
+  --arg message "$MESSAGE" \
+  --arg content "$encoded" \
+  --arg branch "$BRANCH" \
+  --arg sha "$existing_sha" \
+  '{message: $message, content: $content, branch: $branch}
+   + (if $sha == "" then {} else {sha: $sha} end)')
+
+curl -fsS -X PUT "${AUTH[@]}" "$API/repos/$REPO/contents/$FILE" -d "$payload" >/dev/null
+echo "published $FILE to $BRANCH"

--- a/.github/workflows/staggered-scheduling.yml
+++ b/.github/workflows/staggered-scheduling.yml
@@ -27,6 +27,9 @@ permissions:
 
 env:
   SCHEDULE_FILE: .github/scheduling/schedule.json
+  # Cross-run state, deliberately NOT on `main`: that branch is protected behind a merge
+  # queue, so a direct push from CI is rejected (GH006) and the job fails every run.
+  SCHEDULE_STATE_BRANCH: automation/staggered-schedule
   REPOS_PER_DAY: 10
   MAX_CONCURRENT_WORKFLOWS: 3
 
@@ -96,6 +99,23 @@ jobs:
         REPO_COUNT=$(jq 'length' repositories.json)
         echo "repo_count=$REPO_COUNT" >> $GITHUB_OUTPUT
 
+    - name: Restore schedule state
+      run: |
+        # Fail OPEN on every unreadable condition: a missing branch or file simply means "no
+        # prior schedule", which `plan` already handles. This step must never fail the run.
+        rm -f "${{ env.SCHEDULE_FILE }}"
+        if git fetch origin "${{ env.SCHEDULE_STATE_BRANCH }}" --depth 1 --quiet 2>/dev/null; then
+          mkdir -p "$(dirname "${{ env.SCHEDULE_FILE }}")"
+          if git show "FETCH_HEAD:${{ env.SCHEDULE_FILE }}" > "${{ env.SCHEDULE_FILE }}" 2>/dev/null; then
+            echo "restored schedule from ${{ env.SCHEDULE_STATE_BRANCH }}"
+          else
+            rm -f "${{ env.SCHEDULE_FILE }}"
+            echo "state branch carries no schedule yet"
+          fi
+        else
+          echo "no state branch yet — starting from an empty schedule"
+        fi
+
     - name: Plan staggered schedule
       id: generate
       env:
@@ -113,20 +133,16 @@ jobs:
           --today "$TODAY"
 
     - name: Save schedule
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         mkdir -p "$(dirname "${{ env.SCHEDULE_FILE }}")"
         mv schedule.json "${{ env.SCHEDULE_FILE }}"
 
-        git config user.name "github-actions[bot]"
-        git config user.email "github-actions[bot]@users.noreply.github.com"
-        git add "${{ env.SCHEDULE_FILE }}"
-
-        if git diff --staged --quiet; then
-          echo "No schedule changes to commit"
-        else
-          git commit -m "chore: update staggered schedule [skip ci]"
-          git push
-        fi
+        bash .github/scripts/publish-schedule-state.sh \
+          "${{ env.SCHEDULE_FILE }}" \
+          "${{ env.SCHEDULE_STATE_BRANCH }}" \
+          "chore: update staggered schedule [skip ci]"
 
     - name: Check today's schedule
       id: check-today
@@ -243,10 +259,20 @@ jobs:
       if: always()
       env:
         SCHEDULE_DATE: ${{ needs.calculate-schedule.outputs.schedule_date }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         if [ -z "$SCHEDULE_DATE" ]; then
           echo "No schedule date was executed; skipping status update"
           exit 0
+        fi
+
+        # This job checks out `main`, which no longer carries the schedule — pull it from the
+        # state branch or the completion below would silently never run.
+        rm -f "${{ env.SCHEDULE_FILE }}"
+        if git fetch origin "${{ env.SCHEDULE_STATE_BRANCH }}" --depth 1 --quiet 2>/dev/null; then
+          mkdir -p "$(dirname "${{ env.SCHEDULE_FILE }}")"
+          git show "FETCH_HEAD:${{ env.SCHEDULE_FILE }}" > "${{ env.SCHEDULE_FILE }}" 2>/dev/null \
+            || rm -f "${{ env.SCHEDULE_FILE }}"
         fi
 
         if [ -f "${{ env.SCHEDULE_FILE }}" ]; then
@@ -255,11 +281,10 @@ jobs:
             --date "$SCHEDULE_DATE" \
             --completed-at "$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
 
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add ${{ env.SCHEDULE_FILE }}
-          git commit -m "chore: mark $SCHEDULE_DATE schedule as completed [skip ci]" || echo "No changes to commit"
-          git push || echo "No changes to push"
+          bash .github/scripts/publish-schedule-state.sh \
+            "${{ env.SCHEDULE_FILE }}" \
+            "${{ env.SCHEDULE_STATE_BRANCH }}" \
+            "chore: mark $SCHEDULE_DATE schedule as completed [skip ci]"
         fi
 
   monitor-quota:


### PR DESCRIPTION
`main` is protected behind a merge queue with 8 required checks, so the "Save schedule" step's bare `git push` was rejected on **every** scheduled run:

```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through the merge queue
! [remote rejected] main -> main (protected branch hook declined)
```

Observed on run [31230155414](https://github.com/organvm-i-theoria/.github/actions/runs/31230155414). That step had no fail-open guard, so the job failed daily and would have forever. The second push site (`Update schedule status`) was already tolerant (`git push || echo ...`), so it failed *silently* instead — the same defect, only quieter.

## Why a branch, not the merge queue

The schedule is cross-run automation state, not reviewable source. Routing a daily bot commit through a queue with 8 required checks would spend CI on a machine-written JSON file and pile up an unmergeable PR per day. State now lives on `automation/staggered-schedule`.

## Why the Contents API, not `git push`

Publishing to another branch with git means checking it out, which swaps the working tree out from under the later steps that still need `src/automation/scripts/` and `repos_today.txt`. The Contents API writes a branch without touching the checkout. `contents: write` is already granted by the workflow.

## Changes

- **new** `.github/scripts/publish-schedule-state.sh` — one shared publisher, used by both sites (creates the state branch on first use, skips no-op writes so the branch doesn't accumulate an empty commit per day, and handles the create-vs-update blob-sha asymmetry that would otherwise 422).
- `staggered-scheduling.yml` — declares `SCHEDULE_STATE_BRANCH`, restores the schedule before planning, and calls the publisher instead of committing to `main`.

## Regression guarded

`execute-today-schedule` checks out `main`, which no longer carries the schedule. Without a restore its `if [ -f ... ]` would be false on every run and completions would **silently stop being recorded** — so both jobs restore from the state branch before use. Every restore fails open: a missing branch or file just means "no prior schedule", which `plan` already handles.

## Verification

- Patch applied by asserted anchors — a no-op string-replace would have shipped a fix that changed nothing; the patcher exits non-zero on any anchor missing or matching more than once, and asserts no bare `git push` survives.
- `yaml.safe_load` parses; all 4 jobs and the new step resolve in order.
- The repo's own pre-commit suite passes on both files, including **shellcheck** and **check yaml**.
- Not verified: a live scheduled run. The next `0 0 * * *` firing (or a `workflow_dispatch`) is the real proof; the first run will create the state branch.

`.github/scheduling/schedule.json` remains on `main` but is now unread — safe to delete separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RzELciaZt1hwavDvA4ey4G

## Summary by Sourcery

Persist staggered scheduling state to a dedicated automation branch using the GitHub Contents API instead of pushing directly to protected main, ensuring scheduled runs no longer fail and state remains consistent across workflows.

Enhancements:
- Introduce a shared publish-schedule-state script that writes schedule JSON to an unprotected state branch via the GitHub Contents API, avoiding bare git pushes and unnecessary daily commits.
- Restore schedule state from the dedicated branch at the start of planning and completion jobs so cross-run automation state is preserved even though main no longer carries the schedule.
- Make schedule restoration and publication fail-open when state is missing or unchanged, preventing scheduled jobs from failing on absent branches or no-op updates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved staggered scheduling state management through a dedicated automation branch.
  * Schedule state is restored before planning and status updates, including when state is unavailable.
  * Updated schedule progress is published automatically after scheduling and completion updates.
  * Added support for creating or updating schedule state reliably across environments.

* **Bug Fixes**
  * Prevented scheduling automation from requiring direct commits to the protected main branch.
  * Avoided unnecessary updates when schedule state is missing or unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->